### PR TITLE
fix: exibição modal de livro duplicado

### DIFF
--- a/src/constants/keys.ts
+++ b/src/constants/keys.ts
@@ -1,0 +1,4 @@
+const BOOKS_QUERY_KEY = "books";
+const BOOKSHELVES_QUERY_KEY = "bookshelves";
+
+export { BOOKS_QUERY_KEY, BOOKSHELVES_QUERY_KEY };

--- a/src/modules/bookUpsert/bookUpsert.tsx
+++ b/src/modules/bookUpsert/bookUpsert.tsx
@@ -11,7 +11,7 @@ import { Button } from "@/components/ui/button";
 import { SelectField } from "../home/components/select/select.";
 import { Checkbox } from "@/components/ui/checkbox";
 import { DatePicker } from "../home/components/datePicker/datePicker";
-import { useBookDialog } from "./useBookDialog";
+import { useBookDialog } from "./hooks/useBookDialog";
 import { genders } from "@/modules/home/utils/genderBook";
 
 import {
@@ -51,10 +51,10 @@ export function BookUpsert({
     form,
     reset,
     handleSubmit,
-    control, 
-    checkboxes, 
-    isEdit, 
-    isLoadingBookShelfs, 
+    control,
+    checkboxes,
+    isEdit,
+    isLoadingBookShelfs,
     bookshelfOptions,
     handleConfirmCreateBook,
   } = useBookDialog({
@@ -88,8 +88,9 @@ export function BookUpsert({
         }}
       >
         <DialogContent
-          className={`h-full sm:h-[80%] w-full ${isLoggedIn ? "overflow-y-auto" : "overflow-hidden"
-            }`}
+          className={`h-full sm:h-[80%] w-full ${
+            isLoggedIn ? "overflow-y-auto" : "overflow-hidden"
+          }`}
         >
           <BlurOverlay showOverlay={!isLoggedIn}>
             <DialogHeader>

--- a/src/modules/bookUpsert/bookUpsert.tsx
+++ b/src/modules/bookUpsert/bookUpsert.tsx
@@ -54,7 +54,7 @@ export function BookUpsert({
     control,
     checkboxes,
     isEdit,
-    isLoadingBookShelfs,
+    isLoadingBookshelves,
     bookshelfOptions,
     handleConfirmCreateBook,
   } = useBookDialog({
@@ -330,7 +330,7 @@ export function BookUpsert({
                         Deseja adicionar esse livro a uma estante?
                       </Label>
                     </div>
-                    {!isLoadingBookShelfs && isAddToShelfEnabled && (
+                    {!isLoadingBookshelves && isAddToShelfEnabled && (
                       <SelectField
                         items={bookshelfOptions}
                         value={selectedShelfId}
@@ -338,7 +338,7 @@ export function BookUpsert({
                         placeholder="Selecione uma estante"
                       />
                     )}
-                    {isLoadingBookShelfs && (
+                    {isLoadingBookshelves && (
                       <p className="text-sm text-muted-foreground">
                         Carregando estantes...
                       </p>

--- a/src/modules/bookUpsert/bookUpsert.tsx
+++ b/src/modules/bookUpsert/bookUpsert.tsx
@@ -57,6 +57,7 @@ export function BookUpsert({
     isLoadingBookshelves,
     bookshelfOptions,
     handleConfirmCreateBook,
+    handleOnChangePageNumber,
   } = useBookDialog({
     bookData,
     setIsBookFormOpen,
@@ -165,10 +166,10 @@ export function BookUpsert({
                   control={control}
                   name="pages"
                   render={({ field }) => {
-                    const value =
-                      field.value === undefined || field.value === null
-                        ? undefined
-                        : field.value;
+                    const isEmptyField =
+                      field.value === undefined || field.value === null;
+
+                    const value = isEmptyField ? undefined : field.value;
 
                     return (
                       <FormItem>
@@ -178,12 +179,7 @@ export function BookUpsert({
                             type="number"
                             {...field}
                             value={value ?? ""}
-                            onChange={(e) => {
-                              const val = e.target.value;
-                              const parsed =
-                                val === "" ? undefined : Number(val);
-                              field.onChange(parsed);
-                            }}
+                            onChange={(e) => handleOnChangePageNumber(field, e)}
                           />
                         </FormControl>
                         <FormMessage />

--- a/src/modules/bookUpsert/hooks/useBookDialog.ts
+++ b/src/modules/bookUpsert/hooks/useBookDialog.ts
@@ -3,9 +3,9 @@ import { BookCreateValidator, Status } from "@/types/books.types";
 import { BookUpsertService } from "../services/bookUpsert.service";
 import { toast } from "sonner";
 import { BookshelfService } from "../../shelves/services/booksshelves.service";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { UseCreateBookDialog } from "../bookUpsert.types";
-import { useForm } from "react-hook-form";
+import { ControllerRenderProps, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { bookCreateSchema } from "@/modules/home/validators/createBook.validator";
 import { SelectedBookshelf } from "../../shelves/types/bookshelves.types";
@@ -150,6 +150,18 @@ export function useBookDialog({
     return createBook.mutate(data);
   };
 
+  const handleOnChangePageNumber = useCallback(
+    (
+      field: ControllerRenderProps<BookCreateValidator, "pages">,
+      e: ChangeEvent<HTMLInputElement>
+    ) => {
+      const val = e.target.value;
+      const parsed = val === "" ? undefined : Number(val);
+      field.onChange(parsed);
+    },
+    []
+  );
+
   const handleConfirmCreateBook = async () => {
     setIsDuplicateBookDialogOpen(false);
     const formData = form.getValues();
@@ -185,5 +197,7 @@ export function useBookDialog({
     isEdit,
     isLoadingBookshelves,
     bookshelfOptions,
+
+    handleOnChangePageNumber,
   };
 }

--- a/src/modules/bookUpsert/hooks/useBookDialog.ts
+++ b/src/modules/bookUpsert/hooks/useBookDialog.ts
@@ -1,14 +1,14 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { BookCreateValidator, Status } from "@/types/books.types";
-import { BookUpsertService } from "./services/bookUpsert.service";
+import { BookUpsertService } from "../services/bookUpsert.service";
 import { toast } from "sonner";
-import { BookshelfService } from "../shelves/services/booksshelves.service";
+import { BookshelfService } from "../../shelves/services/booksshelves.service";
 import { useCallback, useEffect, useState } from "react";
-import { UseCreateBookDialog } from "./bookUpsert.types";
+import { UseCreateBookDialog } from "../bookUpsert.types";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { bookCreateSchema } from "@/modules/home/validators/createBook.validator";
-import { SelectedBookshelf } from "../shelves/types/bookshelves.types";
+import { SelectedBookshelf } from "../../shelves/types/bookshelves.types";
 
 export function useBookDialog({
   bookData,
@@ -19,7 +19,8 @@ export function useBookDialog({
   const [selected, setSelected] = useState<Status | null>(null);
   const [isAddToShelfEnabled, setIsAddToShelfEnabled] = useState(false);
   const [selectedShelfId, setSelectedShelfId] = useState("");
-  const [isDuplicateBookDialogOpen, setIsDuplicateBookDialogOpen] = useState<boolean>(false);
+  const [isDuplicateBookDialogOpen, setIsDuplicateBookDialogOpen] =
+    useState<boolean>(false);
   const isEdit: boolean = Boolean(bookData && bookData.id);
   const service = new BookUpsertService();
 
@@ -78,7 +79,6 @@ export function useBookDialog({
 
   const createBook = useMutation({
     mutationFn: async (data: BookCreateValidator) => {
-
       if (isEdit) {
         if (!bookData || !bookData.id) {
           throw new Error("Erro inesperado.");
@@ -137,7 +137,7 @@ export function useBookDialog({
 
   const onSubmit = async (data: BookCreateValidator) => {
     const isDuplicate = await service.checkDuplicateBook(data.title);
-    if (isDuplicate) {
+    if (isDuplicate && !isEdit) {
       setIsDuplicateBookDialogOpen(true);
       setIsBookFormOpen(false);
       return;
@@ -145,11 +145,11 @@ export function useBookDialog({
     return createBook.mutate(data);
   };
 
-  const handleConfirmCreateBook = async() => {
+  const handleConfirmCreateBook = async () => {
     setIsDuplicateBookDialogOpen(false);
     const formData = form.getValues();
     createBook.mutate(formData);
-  }
+  };
 
   return {
     onSubmit,
@@ -175,10 +175,10 @@ export function useBookDialog({
     form,
     reset,
     handleSubmit,
-    control, 
-    checkboxes, 
-    isEdit, 
-    isLoadingBookShelfs, 
+    control,
+    checkboxes,
+    isEdit,
+    isLoadingBookShelfs,
     bookshelfOptions,
   };
 }


### PR DESCRIPTION
## Summary by Sourcery

Prevent the duplicate book confirmation modal from appearing when editing existing books, while updating import paths and code formatting in the book upsert dialog and component.

Bug Fixes:
- Show duplicate-book dialog only on new book creation, not on edits.

Enhancements:
- Update import paths for BookUpsertService, BookshelfService, and related types to match new folder structure.
- Cleanup code formatting and spacing in useBookDialog hook and BookUpsert component.