### PR TITLE
Fix bookshelf reorder accessibility and runtime/test consistency

### DIFF
--- a/src/app/api/shelves/[id]/books/reorder/route.test.ts
+++ b/src/app/api/shelves/[id]/books/reorder/route.test.ts
@@ -44,7 +44,7 @@ describe("POST /api/shelves/[id]/books/reorder", () => {
           ],
         }),
       }),
-      { params: Promise.resolve({ id: "s1" }) },
+      { params: { id: "s1" } },
     );
 
     expect(res.status).toBe(401);
@@ -81,7 +81,7 @@ describe("POST /api/shelves/[id]/books/reorder", () => {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ bookIds: [idB, idA] }),
       }),
-      { params: Promise.resolve({ id: "s1" }) },
+      { params: { id: "s1" } },
     );
 
     expect(res.status).toBe(200);

--- a/src/app/api/shelves/[id]/books/reorder/route.ts
+++ b/src/app/api/shelves/[id]/books/reorder/route.ts
@@ -9,11 +9,11 @@ const bodySchema = z.object({
 });
 
 type Ctx = {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 };
 
 export async function POST(request: Request, ctx: Ctx) {
-  const { id: shelfId } = await ctx.params;
+  const { id: shelfId } = ctx.params;
   const supabase = await createClient();
   const auth = await requireUser(supabase);
   if (auth.errorResponse) return auth.errorResponse;

--- a/src/modules/bookshelves/components/BookshelfBooksSortableGrid.test.tsx
+++ b/src/modules/bookshelves/components/BookshelfBooksSortableGrid.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import BookshelfBooksSortableGrid from "./BookshelfBooksSortableGrid";
+import type { BookDomain } from "@/types/books.types";
+
+vi.mock("@/components/bookCard", () => ({
+  BookCard: ({ book }: { book: BookDomain }) => <div>{book.title}</div>,
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  DndContext: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  KeyboardSensor: class {},
+  PointerSensor: class {},
+  closestCenter: vi.fn(),
+  useSensor: vi.fn(() => ({})),
+  useSensors: vi.fn(() => []),
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  arrayMove: vi.fn(),
+  rectSortingStrategy: {},
+  sortableKeyboardCoordinates: vi.fn(),
+  useSortable: vi.fn(({ id }: { id: string }) => ({
+    attributes: { "data-sortable-id": id },
+    listeners: { onPointerDown: vi.fn() },
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  })),
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: vi.fn(() => undefined) } },
+}));
+
+const BOOK: BookDomain = {
+  id: "book-1",
+  title: "Livro 1",
+  author: "Autor",
+  chosen_by: "u",
+  pages: 1,
+  readerIds: [],
+  readersDisplay: "",
+  gender: null,
+  image_url: "/x.svg",
+  user_id: "u",
+};
+
+describe("BookshelfBooksSortableGrid", () => {
+  it("marks drag handle as disabled and not focusable when reorder is disabled", () => {
+    render(
+      <BookshelfBooksSortableGrid
+        shelfId="s1"
+        books={[BOOK]}
+        isLoading={false}
+        isFetched
+        isError={false}
+        emptyMessage="vazio"
+        onReorder={vi.fn()}
+        reorderDisabled
+      />,
+    );
+
+    const handle = screen.getByRole("button", {
+      name: 'Reordenação indisponível: Livro 1',
+    });
+
+    expect(handle).toHaveAttribute("aria-disabled", "true");
+    expect(handle).toHaveAttribute("tabindex", "-1");
+  });
+});

--- a/src/modules/bookshelves/components/BookshelfBooksSortableGrid.tsx
+++ b/src/modules/bookshelves/components/BookshelfBooksSortableGrid.tsx
@@ -69,7 +69,8 @@ function SortableShelfBookItem({
   shelfId: string;
   reorderDisabled: boolean;
 }) {
-  const id = book.id ?? "";
+  if (!book.id) return null;
+  const id = book.id;
   const {
     attributes,
     listeners,
@@ -104,9 +105,15 @@ function SortableShelfBookItem({
             "flex w-8 shrink-0 cursor-grab touch-none items-center justify-center border-r border-border/50 bg-muted/30 py-3 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
             reorderDisabled && "pointer-events-none cursor-not-allowed opacity-40",
           )}
-          aria-label={`Arrastar para reordenar: ${book.title}`}
-          {...attributes}
-          {...listeners}
+          aria-label={
+            reorderDisabled
+              ? `Reordenação indisponível: ${book.title}`
+              : `Arrastar para reordenar: ${book.title}`
+          }
+          aria-disabled={reorderDisabled}
+          tabIndex={reorderDisabled ? -1 : undefined}
+          {...(reorderDisabled ? {} : attributes)}
+          {...(reorderDisabled ? {} : listeners)}
         >
           <GripVertical className="h-4 w-4 shrink-0" aria-hidden />
         </button>
@@ -128,9 +135,14 @@ export default function BookshelfBooksSortableGrid({
   onReorder,
   reorderDisabled = false,
 }: BookshelfBooksSortableGridProps) {
-  const itemIds = useMemo(
-    () => books.map((b) => b.id).filter((id): id is string => Boolean(id)),
+  const sortableBooks = useMemo(
+    () => books.filter((book): book is BookDomain & { id: string } => Boolean(book.id)),
     [books],
+  );
+
+  const itemIds = useMemo(
+    () => sortableBooks.map((b) => b.id),
+    [sortableBooks],
   );
 
   const sensors = useSensors(
@@ -151,9 +163,9 @@ export default function BookshelfBooksSortableGrid({
       const newIndex = ids.indexOf(String(over.id));
       if (oldIndex < 0 || newIndex < 0) return;
       const next = arrayMove(ids, oldIndex, newIndex);
-      onReorder(books, next);
+      onReorder(sortableBooks, next);
     },
-    [books, itemIds, onReorder],
+    [itemIds, onReorder, sortableBooks],
   );
 
   if (isError) {
@@ -199,7 +211,7 @@ export default function BookshelfBooksSortableGrid({
           role="list"
           aria-label="Livros na estante, reordenáveis por arrastar"
         >
-          {books.map((book) => (
+          {sortableBooks.map((book) => (
             <div key={book.id} role="listitem" className="min-w-0">
               <SortableShelfBookItem
                 book={book}

--- a/src/modules/bookshelves/hooks/useBookshelfBookOrder.test.tsx
+++ b/src/modules/bookshelves/hooks/useBookshelfBookOrder.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import React from "react";
 import { useBookshelfBookOrder } from "./useBookshelfBookOrder";
 import type { BookDomain } from "@/types/books.types";
+import { bookshelfBooksQueryKey } from "@/modules/bookshelves/bookshelfBooksQueryKey";
 
 const book = (id: string): BookDomain => ({
   id,
@@ -41,7 +42,7 @@ describe("useBookshelfBookOrder", () => {
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     vi.spyOn(client, "invalidateQueries").mockResolvedValue(undefined as never);
     const books = [book("a"), book("b")];
-    client.setQueryData(["bookshelf-books", "s1"], books);
+    client.setQueryData(bookshelfBooksQueryKey("s1"), books);
 
     const { result } = renderHook(() => useBookshelfBookOrder("s1"), {
       wrapper: wrapper(client),
@@ -51,9 +52,10 @@ describe("useBookshelfBookOrder", () => {
       result.current.applyReorder(books, ["b", "a"]);
     });
 
-    expect(client.getQueryData<BookDomain[]>(["bookshelf-books", "s1"])?.map((x) => x.id)).toEqual([
-      "b",
-      "a",
-    ]);
+    expect(
+      client
+        .getQueryData<BookDomain[]>(bookshelfBooksQueryKey("s1"))
+        ?.map((x) => x.id),
+    ).toEqual(["b", "a"]);
   });
 });


### PR DESCRIPTION
### Motivation
- The drag handle remained focusable and announced as draggable when `reorderDisabled` is true, which can confuse keyboard and assistive-technology users.
- The API route typed `ctx.params` as a `Promise` which differs from the Next.js runtime shape and can lead to test/runtime mismatches.
- Falsy book IDs could result in empty-string DnD ids and inconsistent drag behavior when rendering sortable items.

### Description
- Align the reorder route context to the Next.js runtime by typing `ctx.params` as a plain object and reading it synchronously in `POST` (`src/app/api/shelves/[id]/books/reorder/route.ts`).
- Update route tests to pass `{ params: { id } }` instead of a promised params object (`src/app/api/shelves/[id]/books/reorder/route.test.ts`).
- Improve sortable item accessibility by returning early for books without `id`, filtering to only books with defined ids, and updating the drag handle to set `aria-disabled`, a disabled-specific `aria-label`, and `tabIndex={-1}` while removing drag attributes/listeners when disabled (`src/modules/bookshelves/components/BookshelfBooksSortableGrid.tsx`).
- Ensure `onReorder` and the sortable `itemIds` operate on the filtered `sortableBooks` list to avoid empty/duplicate DnD ids (`src/modules/bookshelves/components/BookshelfBooksSortableGrid.tsx`).
- Make the `useBookshelfBookOrder` unit test seed/assert the cache using `bookshelfBooksQueryKey("s1")` instead of the literal key to keep behavior consistent with the hook (`src/modules/bookshelves/hooks/useBookshelfBookOrder.test.tsx`).
- Add a component unit test that verifies the drag handle is marked inaccessible and removed from tab order when `reorderDisabled` is set (`src/modules/bookshelves/components/BookshelfBooksSortableGrid.test.tsx`).

### Testing
- Ran the focused test suite with `npm run test -- src/app/api/shelves/[id]/books/reorder/route.test.ts src/modules/bookshelves/hooks/useBookshelfBookOrder.test.tsx src/modules/bookshelves/components/BookshelfBooksSortableGrid.test.tsx` and all tests passed.
- The added component test validates the handle attributes (`aria-disabled` and `tabIndex`) and the existing route and hook tests still succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3f18e38f48328bedc0e11fe2aacfc)

## Summary by Sourcery

Improve bookshelf book reordering behavior and accessibility while aligning API route typing and tests with the Next.js runtime.

Bug Fixes:
- Prevent sortable items from rendering with empty or duplicate drag-and-drop IDs by filtering to books with defined IDs and operating reorder logic on that subset.
- Ensure the bookshelf reorder API route context matches the Next.js runtime by treating route params as a synchronous object instead of a Promise, updating both implementation and tests accordingly.

Enhancements:
- Make the bookshelf drag handle inaccessible when reordering is disabled by updating aria attributes, labels, and tab behavior for better keyboard and assistive-technology support.
- Align the bookshelf book order hook test cache setup with the production query key helper to keep behavior and expectations consistent across code and tests.

Tests:
- Add a unit test to verify that the bookshelf drag handle is disabled and removed from the tab order when reordering is disabled.