### PR TITLE
Address filter typing, clarify isReread parsing, and re-enable build checks

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,10 +2,10 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   eslint: {
-    ignoreDuringBuilds: true,
+    ignoreDuringBuilds: false,
   },
   images: {
     remotePatterns: [

--- a/src/modules/home/components/filtersSheet/filters.tsx
+++ b/src/modules/home/components/filtersSheet/filters.tsx
@@ -106,7 +106,7 @@ export default function FiltersSheet({
               id="filter-reread"
               checked={localFilters.isReread ?? false}
               onCheckedChange={(checked) =>
-                handleFilterChange("isReread", checked || false)
+                handleFilterChange("isReread", checked)
               }
             />
             <Label htmlFor="filter-reread" className="text-sm font-semibold text-foreground/80">

--- a/src/modules/home/components/filtersSheet/hooks/useFiltersSheet.ts
+++ b/src/modules/home/components/filtersSheet/hooks/useFiltersSheet.ts
@@ -29,16 +29,21 @@ export const useLocalFilters = (initialFilters: FiltersOptions) => {
   const [localFilters, setLocalFilters] =
     useState<FiltersOptions>(initialFilters);
 
+  type FiltersValue<K extends keyof FiltersOptions> = FiltersOptions[K];
+
   const handleFilterChange = useCallback(
-    (key: keyof FiltersOptions, value: string | string[] | boolean) => {
+    <K extends keyof FiltersOptions>(key: K, value: FiltersValue<K>) => {
       setLocalFilters((prev) => {
-        if (typeof value === "boolean") {
-          return { ...prev, [key]: value };
+        if (Array.isArray(value)) {
+          return {
+            ...prev,
+            [key]: value.filter(Boolean),
+          };
         }
-        const values = Array.isArray(value) ? value : [value];
+
         return {
           ...prev,
-          [key]: values.filter(Boolean),
+          [key]: value,
         };
       });
     },

--- a/src/utils/parseFiltersFromSearchParams/parseFiltersFromSearchParams.ts
+++ b/src/utils/parseFiltersFromSearchParams/parseFiltersFromSearchParams.ts
@@ -32,7 +32,8 @@ export function parseFiltersFromSearchParams(searchParams: URLSearchParams): {
   const rawYear = searchParams.get("year");
   const year = rawYear ? parseInt(rawYear, 10) : undefined;
   const myBooks = searchParams.get("myBooks") === "true";
-  const isReread = searchParams.get("isReread") === "true" || undefined;
+  const isReread =
+    searchParams.get("isReread") === "true" ? true : undefined;
   const viewParam = searchParams.get("view");
   const view = viewParam === "joint" ? "joint" : "todos";
 


### PR DESCRIPTION
### Motivation
- Prevent type/lint regressions from being silently skipped during `next build` by re-enabling build-time checks.
- Preserve key/value type safety for filter updates so callers cannot pass invalid value types for a given filter key.
- Make `isReread` parsing explicit to avoid boolean/`undefined` short-circuiting that obscures intent.

### Description
- Set `typescript.ignoreBuildErrors` and `eslint.ignoreDuringBuilds` to `false` in `next.config.ts` to re-enable build checks.
- Refactored `handleFilterChange` in `src/modules/home/components/filtersSheet/hooks/useFiltersSheet.ts` to be generic over `K extends keyof FiltersOptions` and derive the value type from `FiltersOptions[K]`, restoring per-key typing and preserving array cleanup.
- Updated the reread `Switch` in `src/modules/home/components/filtersSheet/filters.tsx` to pass the boolean `checked` directly to `handleFilterChange`.
- Rewrote `isReread` parsing in `src/utils/parseFiltersFromSearchParams/parseFiltersFromSearchParams.ts` to use an explicit ternary (`... === "true" ? true : undefined`) for clarity.

### Testing
- Ran `yarn type-check`, which failed to run in this environment due to the local Yarn workspace/lockfile state reporting the package as missing from the lockfile.
- Attempted `yarn install` to allow type checking, but resolution failed with a `403` during dependency fetch in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e198dd0248832885bd4bbd9f619b57)

## Summary by Sourcery

Reinstate strict build-time checks and tighten filter handling and parsing for the home filters sheet.

Bug Fixes:
- Fix filters sheet local state updates to respect per-filter value types while still cleaning array values.
- Ensure reread filter state is passed and parsed as an explicit boolean or undefined instead of relying on short-circuiting behavior.

Build:
- Re-enable TypeScript and ESLint checks during Next.js builds by disallowing ignored build errors.