### PR TITLE
fix(auth): clear stale sb-* cookies in middleware on token error

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,6 +1,14 @@
 import { type CookieOptions, createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 
+function isStaleTokenError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const err = error as { __isAuthError?: boolean; name?: string };
+  return (
+    err.__isAuthError === true && err.name !== "AuthSessionMissingError"
+  );
+}
+
 export async function updateSession(request: NextRequest) {
   const supabaseResponse = NextResponse.next({
     request,
@@ -32,7 +40,20 @@ export async function updateSession(request: NextRequest) {
     },
   );
 
-  await supabase.auth.getUser();
+  const { error } = await supabase.auth.getUser();
+
+  if (error && isStaleTokenError(error)) {
+    request.cookies.getAll().forEach((cookie) => {
+      if (cookie.name.startsWith("sb-")) {
+        supabaseResponse.cookies.set({
+          name: cookie.name,
+          value: "",
+          maxAge: 0,
+          path: "/",
+        });
+      }
+    });
+  }
 
   return supabaseResponse;
 }


### PR DESCRIPTION
When a deploy changes @supabase/ssr dependencies, existing sb-* cookies can become incompatible and cause getUser() to fail with AuthApiError (e.g. refresh_token_not_found). The middleware now detects this and expires those cookies in the response, so the very next request arrives without stale tokens and the user is treated as logged-out correctly.

AuthSessionMissingError (no session at all) is intentionally excluded to avoid touching cookies for anonymous visitors.

Made-with: Cursor

## Summary by Sourcery

Bug Fixes:
- Expire sb-* cookies in middleware when Supabase getUser() returns an auth error indicating incompatible or stale tokens, ensuring users are correctly treated as logged out instead of failing requests.