### PR TITLE
Enforce solo book privacy and locked readers

### DIFF
--- a/BUSINESS_RULES.md
+++ b/BUSINESS_RULES.md
@@ -20,7 +20,7 @@
 - **RN09 - Limpeza de Filtros:** O botão "Limpar" deve ficar ativo apenas se houver busca ativa, filtros de gênero/status/ano selecionados ou se o filtro de leitores for diferente do padrão.
 - **RN16 - Filtro de Ano Híbrido (Query):** O filtro por ano deve retornar livros que foram **finalizados** naquele ano (`end_date`) OU que foram **planejados** para iniciar naquele ano (`planned_start_date`).
 
-- **RN17 - Exibição de Livros (Query):** Caso usuário logado, exiba os filtros conforme regras, caso contrário exiba todos os livros.
+- **RN17 - Exibição de Livros (Query):** Caso usuário logado, exiba os filtros conforme regras, caso contrário exiba todos os livros (exceto livros individuais privados conforme **RN56**).
 
 - **RN18 - Guard de Autenticação em Queries:** Todo `useQuery` que acessa uma rota autenticada (`/api/users`, `/api/shelves`) DEVE declarar `enabled: isLoggedIn`. Queries sem esse guard disparam a requisição mesmo para sessões não autenticadas, resultando em 401 e erro em cascata.
 
@@ -34,7 +34,7 @@
   - **Sugestão de inclusão na leitura:** se o usuário **não** participa, o livro existente está com **`status = not_started`** e há **mútuo seguir** (**RN39–RN40**) entre o usuário atual e o leitor de referência — prioriza-se `chosen_by` quando for terceiro; caso contrário outro participante em `readers` — deve ser oferecido o fluxo de vincular o usuário ao livro existente (modal de sugestão).
   - **Sem sugestão:** se não houver match de título/autor, ou houver match mas o usuário não participa e **não** se cumprir `not_started` + mútuo seguir, o fluxo segue como **novo cadastro** sem modal de sugestão.
 
-- **RN20 - Usuario não logado:** Não pode navegar entre telas, não pode fazer crud de absolutamente nada na aplicação e deve ver todos os livros cadastrados.
+- **RN20 - Usuario não logado:** Não pode navegar entre telas, não pode fazer crud de absolutamente nada na aplicação e deve ver todos os livros cadastrados — **exceto livros individuais privados** (conforme **RN56**).
 
 - **RN21 - Usuario não logado - filtros:** Não pode aplicar filtros e não deve ver a opção de filtros.
 - **RN22 - Busca Unificada (Autocomplete):** O autocomplete da busca inicial deve retornar resultados de **livros** e **autores** em um único fluxo de interação.
@@ -61,7 +61,7 @@
 - **RN33 - Seleção Inicial de Leitores na Visão Todos:**
   - Ao abrir a Home logado, na visão **Todos**, apenas o leitor do usuário atual deve iniciar marcado.
   - Ao selecionar outros leitores, a seleção deve acumular no filtro da visão **Todos**.
-  - O leitor padrão pode ser removido manualmente pelo usuário.
+  - O leitor do próprio usuário logado **não pode ser removido manualmente** (conforme **RN57**).
 - **RN34 - Paginação da Visão Todos:**
   - A visão **Todos** deve respeitar `PAGE_SIZE = 8` e paginação por página atual.
   - Alterações na seleção de leitores na visão **Todos** devem gerar nova query (query key distinta) para evitar stale cache.
@@ -114,7 +114,7 @@
 
 As regras abaixo são aplicadas no banco (Row Level Security). A UI continua responsável por **RN20** (visitante sem CRUD); no Postgres, o papel `anon` tem apenas **SELECT** nas tabelas necessárias para listagem e autocomplete (**RN17**, **RN22**), e **nenhuma** operação de escrita.
 
-- **RN41 - Visitante (`anon`):** Apenas `SELECT` em `books`, `authors` e demais tabelas expostas para leitura pública. `INSERT` / `UPDATE` / `DELETE` são negados para `anon` (alinhado a **RN20** e **RN21**).
+- **RN41 - Visitante (`anon`):** Apenas `SELECT` em `books`, `authors` e demais tabelas expostas para leitura pública. `INSERT` / `UPDATE` / `DELETE` são negados para `anon` (alinhado a **RN20** e **RN21**). O `SELECT` em `books` é limitado pela policy `books_select_non_solo_or_owner`: livros individuais privados (**RN56**) são invisíveis para `anon`.
 
 - **RN42 - Escrita em `books` (leitura coletiva):** Um usuário autenticado pode **inserir, atualizar ou excluir** uma linha em `books` somente se participar do livro, isto é, se `auth.uid()` for igual a `user_id` (quando preenchido), ou a `chosen_by`, ou estiver em `readers`. Assim, leitores conjuntos podem editar ou remover o registro conforme o mesmo critério de participação (alinhado a **RN29–RN32** e ao modelo de `readers` / `chosen_by`).
 
@@ -141,3 +141,23 @@ As regras abaixo são aplicadas no banco (Row Level Security). A UI continua res
 - **RN53 - Persistência e salvamento automático:** Ao concluir o gesto de soltar (drop), o sistema persiste imediatamente a nova sequência no banco, sem botão de salvar. Se a persistência falhar, a interface deve notificar o erro e restaurar a ordem anteriormente exibida.
 
 - **RN54 - Novos vínculos na estante:** Ao adicionar um livro a uma estante, o novo vínculo recebe posição ao final da sequência existente naquela estante (comportamento garantido no banco ou na API de criação do vínculo).
+
+## 9. Privacidade e visibilidade
+
+- **RN56 - Privacidade de livros individuais:** Um livro é considerado **individual/privado** quando `array_length(readers, 1) = 1 AND readers[1] = chosen_by`, ou seja, há exatamente um leitor e ele é o mesmo que escolheu o livro. Nesses casos:
+  - O livro é visível **apenas** para o próprio `chosen_by` (dono), independentemente de estar logado ou não.
+  - Usuários anônimos e qualquer outro usuário autenticado **não** recebem a linha na query de `SELECT` (enforçado via RLS policy `books_select_non_solo_or_owner`).
+  - Esta regra sobrepõe **RN20** e **RN41** para esse subconjunto de livros.
+  - O `BookCard` exibe um badge "Privado" (ícone de cadeado) quando `isSoloBook(book) && book.chosen_by === user.id`.
+  - Livros com múltiplos leitores **ou** com `readers[1] ≠ chosen_by` permanecem com visibilidade pública inalterada.
+
+- **RN57 - Leitor obrigatório nas visões "Todos" e "Leitura em conjunto":** Quando o usuário está logado e visualiza as visões **Todos** (`view="todos"`) ou **Leitura em conjunto** (`view="joint"`):
+  - O chip do próprio usuário no filtro de leitores fica **sempre marcado e desabilitado** (`disabled`).
+  - Clicar no chip do próprio usuário não tem efeito (bloqueado em `handleToggleReader`).
+  - O `aria-label` do chip indica "sempre incluído nesta visão".
+  - Mesmo que a URL contenha `readers` sem o ID do usuário logado, os memos `effectiveTodosReaders` (visão Todos) e `effectiveSelectedReaders` (visão Joint) injetam o ID de volta automaticamente.
+  - **Distinção por visão:**
+    - `todos`: não exige leitores adicionais; o usuário pode navegar sozinho.
+    - `joint`: exige **pelo menos 1 outro leitor** além do usuário logado (`needsExtraReader = true` quando apenas o próprio ID está selecionado); mensagem de aviso exibida na UI em âmbar.
+  - A regra não se aplica em `myBooks` (chips de leitor não são exibidos nessa visão).
+  - A regra não se aplica para usuários não logados (`lockedReaderId = undefined`).

--- a/src/components/bookCard/bookCard.tsx
+++ b/src/components/bookCard/bookCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { BookOpen, EllipsisVerticalIcon, Users } from "lucide-react";
+import { BookOpen, EllipsisVerticalIcon, Lock, Users } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { DropdownBook } from "./components/dropdownBook";
@@ -30,6 +30,7 @@ export function BookCard(props: BookCardProps) {
     handleNavigateToQuotes,
     handleConfirmDelete,
     statusDisplay,
+    isOwnSoloBook,
   } = useBookCard(props);
 
   const bookBody = (
@@ -152,6 +153,26 @@ export function BookCard(props: BookCardProps) {
               </span>
             )}
           </div>
+        )}
+
+        {isOwnSoloBook && (
+          <Badge
+            variant="secondary"
+            aria-label="Livro privado — visível apenas para você"
+            className={cn(
+              "w-fit border-none font-medium uppercase",
+              isShelf
+                ? "h-4 px-1.5 text-[9px] py-0 gap-0.5"
+                : "h-5 px-2 text-[10px] py-0 gap-1",
+              "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400",
+            )}
+          >
+            <Lock
+              aria-hidden
+              className={cn(isShelf ? "w-2 h-2" : "w-2.5 h-2.5")}
+            />
+            Privado
+          </Badge>
         )}
 
         {book.is_reread && (

--- a/src/components/bookCard/hooks/useBookCard.ts
+++ b/src/components/bookCard/hooks/useBookCard.ts
@@ -5,6 +5,8 @@ import { useIsLoggedIn } from "@/stores/hooks/useAuth";
 import { useCallback, useMemo } from "react";
 import { BookService } from "@/services/books/books.service";
 import { BookshelfServiceBooks } from "@/modules/bookshelves/services/bookshelvesBooks.service";
+import { BookMapper } from "@/services/books/books.mapper";
+import { useUserStore } from "@/stores/userStore";
 
 export function useBookCard({
   book,
@@ -18,7 +20,14 @@ export function useBookCard({
 
   const router = useRouter();
   const isLogged = useIsLoggedIn();
+  const currentUser = useUserStore((state) => state.user);
   const dropdownTap = useSafeTap(() => dropdownModal.setIsOpen(true));
+
+  const isSoloBook = useMemo(() => BookMapper.isSoloBook(book), [book]);
+  const isOwnSoloBook = useMemo(
+    () => isSoloBook && !!currentUser?.id && book.chosen_by === currentUser.id,
+    [isSoloBook, currentUser?.id, book.chosen_by],
+  );
 
   const shareOnWhatsApp = useCallback(() => {
     const baseUrl = "https://nosso-tbr.vercel.app/";
@@ -173,5 +182,6 @@ export function useBookCard({
     badgeObject,
     handleConfirmDelete,
     statusDisplay,
+    isOwnSoloBook,
   };
 }

--- a/src/modules/home/hooks/useHome.test.ts
+++ b/src/modules/home/hooks/useHome.test.ts
@@ -656,6 +656,234 @@ describe("useHome", () => {
     });
   });
 
+  describe("lockedReaderId — leitor obrigatório (RN57)", () => {
+    it("é undefined quando o usuário não está logado (todos)", () => {
+      (useIsLoggedIn as unknown as Mock).mockReturnValue(false);
+      (useUserStore as unknown as Mock).mockReturnValue(null);
+
+      const { result } = setupHook({ view: "todos" });
+      expect(result.current.lockedReaderId).toBeUndefined();
+    });
+
+    it("é undefined quando o usuário não está logado (joint)", () => {
+      (useIsLoggedIn as unknown as Mock).mockReturnValue(false);
+      (useUserStore as unknown as Mock).mockReturnValue(null);
+
+      const { result } = setupHook({ view: "joint" });
+      expect(result.current.lockedReaderId).toBeUndefined();
+    });
+
+    it("é o user.id quando logado na visão todos", () => {
+      (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
+      (useUserStore as unknown as Mock).mockReturnValue({
+        id: "1",
+        display_name: "Matheus",
+      });
+
+      const { result } = setupHook({ view: "todos" });
+      expect(result.current.lockedReaderId).toBe("1");
+    });
+
+    it("é o user.id quando logado na visão joint", () => {
+      (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
+      (useUserStore as unknown as Mock).mockReturnValue({
+        id: "1",
+        display_name: "Matheus",
+      });
+
+      const { result } = setupHook({ view: "joint" });
+      expect(result.current.lockedReaderId).toBe("1");
+    });
+
+    it("é undefined quando myBooks está ativo", () => {
+      (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
+      (useUserStore as unknown as Mock).mockReturnValue({
+        id: "1",
+        display_name: "Matheus",
+      });
+
+      const { result } = setupHook({ view: "todos", myBooks: true });
+      expect(result.current.lockedReaderId).toBeUndefined();
+    });
+
+    it("handleToggleReader ignorado quando readerId === lockedReaderId (todos)", () => {
+      (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
+      (useUserStore as unknown as Mock).mockReturnValue({
+        id: "1",
+        display_name: "Matheus",
+      });
+      (useUser as Mock).mockReturnValue({
+        users: mockUsers,
+        isLoadingUsers: false,
+      });
+      mockQueryData(0, []);
+
+      const { result } = setupHook({ view: "todos", readers: ["1", "2"] });
+      act(() => result.current.handleToggleReader("1"));
+
+      expect(mockUpdateUrlWithFilters).not.toHaveBeenCalled();
+    });
+
+    it("handleToggleReader ignorado quando readerId === lockedReaderId (joint)", () => {
+      (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
+      (useUserStore as unknown as Mock).mockReturnValue({
+        id: "1",
+        display_name: "Matheus",
+      });
+      (useUser as Mock).mockReturnValue({
+        users: mockUsers,
+        isLoadingUsers: false,
+      });
+
+      const { result } = setupHook({ view: "joint", readers: ["1", "2"] });
+      act(() => result.current.handleToggleReader("1"));
+
+      expect(mockUpdateUrlWithFilters).not.toHaveBeenCalled();
+    });
+
+    it("outro leitor pode ser removido normalmente mesmo com lock ativo (joint)", () => {
+      (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
+      (useUserStore as unknown as Mock).mockReturnValue({
+        id: "1",
+        display_name: "Matheus",
+      });
+      (useUser as Mock).mockReturnValue({
+        users: mockUsers,
+        isLoadingUsers: false,
+      });
+
+      const { result } = setupHook({ view: "joint", readers: ["1", "2"] });
+      act(() => result.current.handleToggleReader("2"));
+
+      expect(mockUpdateUrlWithFilters).toHaveBeenCalledWith(
+        expect.objectContaining({ readers: ["1"] }),
+      );
+    });
+
+    it("effectiveTodosReaders injeta lockedReaderId quando ausente", () => {
+      (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
+      (useUserStore as unknown as Mock).mockReturnValue({
+        id: "1",
+        display_name: "Matheus",
+      });
+      (useUser as Mock).mockReturnValue({
+        users: mockUsers,
+        isLoadingUsers: false,
+      });
+      mockQueryData(0, ["2"]);
+
+      const { result } = setupHook({ view: "todos", readers: ["2"] });
+
+      const key = (useQuery as Mock).mock.calls
+        .at(-1)?.[0]?.queryKey?.find(
+          (k: unknown) => typeof k === "string" && k.startsWith("1"),
+        );
+      expect(key).toContain("1");
+      expect(result.current.lockedReaderId).toBe("1");
+    });
+
+    it("effectiveSelectedReaders injeta lockedReaderId quando ausente na visão joint", () => {
+      (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
+      (useUserStore as unknown as Mock).mockReturnValue({
+        id: "1",
+        display_name: "Matheus",
+      });
+      (useUser as Mock).mockReturnValue({
+        users: mockUsers,
+        isLoadingUsers: false,
+      });
+
+      (useQuery as Mock).mockReturnValue({
+        data: {
+          data: [
+            {
+              id: "book-1",
+              readerIds: ["1", "2"],
+              readersDisplay: "Matheus e Barbara",
+            },
+          ],
+          total: 1,
+        },
+        isFetching: false,
+        isFetched: true,
+        isError: false,
+      });
+
+      const { result } = setupHook({ view: "joint", readers: ["2"] });
+
+      expect(result.current.allBooks?.data).toHaveLength(1);
+    });
+  });
+
+  describe("needsExtraReader (RN57 — joint exige 1 leitor além do logado)", () => {
+    it("é false quando view não é joint", () => {
+      (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
+      (useUserStore as unknown as Mock).mockReturnValue({
+        id: "1",
+        display_name: "Matheus",
+      });
+
+      const { result } = setupHook({ view: "todos", readers: ["1"] });
+      expect(result.current.needsExtraReader).toBe(false);
+    });
+
+    it("é false quando filters.readers está vazio (todos selecionados por padrão)", () => {
+      (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
+      (useUserStore as unknown as Mock).mockReturnValue({
+        id: "1",
+        display_name: "Matheus",
+      });
+
+      const { result } = setupHook({ view: "joint", readers: [] });
+      expect(result.current.needsExtraReader).toBe(false);
+    });
+
+    it("é false quando há outros leitores além do lockedReaderId em joint", () => {
+      (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
+      (useUserStore as unknown as Mock).mockReturnValue({
+        id: "1",
+        display_name: "Matheus",
+      });
+
+      const { result } = setupHook({ view: "joint", readers: ["1", "2"] });
+      expect(result.current.needsExtraReader).toBe(false);
+    });
+
+    it("é true quando apenas lockedReaderId está selecionado em joint", () => {
+      (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
+      (useUserStore as unknown as Mock).mockReturnValue({
+        id: "1",
+        display_name: "Matheus",
+      });
+
+      const { result } = setupHook({ view: "joint", readers: ["1"] });
+      expect(result.current.needsExtraReader).toBe(true);
+    });
+
+    it("é false quando o usuário não está logado em joint", () => {
+      (useIsLoggedIn as unknown as Mock).mockReturnValue(false);
+      (useUserStore as unknown as Mock).mockReturnValue(null);
+
+      const { result } = setupHook({ view: "joint", readers: ["1"] });
+      expect(result.current.needsExtraReader).toBe(false);
+    });
+
+    it("cenário: Matheus(logado), Fabi e Barbara — remover Fabi+Barbara resulta em needsExtraReader=true", () => {
+      (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
+      (useUserStore as unknown as Mock).mockReturnValue({
+        id: "matheus-id",
+        display_name: "Matheus",
+      });
+
+      const { result } = setupHook({
+        view: "joint",
+        readers: ["matheus-id"],
+      });
+      expect(result.current.needsExtraReader).toBe(true);
+      expect(result.current.lockedReaderId).toBe("matheus-id");
+    });
+  });
+
   describe("joint reading readers filters", () => {
     it("keeps readers filter empty when all readers are selected by default", () => {
       (useUser as Mock).mockReturnValue({

--- a/src/modules/home/hooks/useHome.ts
+++ b/src/modules/home/hooks/useHome.ts
@@ -112,6 +112,12 @@ export function useHome() {
   const isAllBooksActive = filters.view !== "joint" && !filters.myBooks;
   const isMyBooksActive = !!(filters.myBooks && isLoggedIn && user?.id);
 
+  const lockedReaderId = useMemo(() => {
+    if (!isLoggedIn || !user?.id || isMyBooksActive) return undefined;
+    if (filters.view === "todos" || filters.view === "joint") return user.id;
+    return undefined;
+  }, [isLoggedIn, user?.id, isMyBooksActive, filters.view]);
+
   const readersObj = useMemo(() => {
     if (isMyBooksActive) {
       return { readers: [], readersDisplay: "" };
@@ -159,9 +165,14 @@ export function useHome() {
       defaultTodosReaders.includes(id),
     );
 
-    if (scopedReaders.length > 0) return scopedReaders;
+    if (scopedReaders.length > 0) {
+      if (lockedReaderId && !scopedReaders.includes(lockedReaderId)) {
+        return [lockedReaderId, ...scopedReaders];
+      }
+      return scopedReaders;
+    }
     return defaultTodosReaders;
-  }, [filters.readers, defaultTodosReaders]);
+  }, [filters.readers, defaultTodosReaders, lockedReaderId]);
 
   const relationshipUserValues = useMemo(() => {
     if (!isAllBooksActive || !isLoggedIn) return undefined;
@@ -287,10 +298,19 @@ export function useHome() {
   const formattedYear = useMemo(() => formatYear(filters.year), [filters.year]);
 
   const allReaderIds = useMemo(() => users.map((u) => u.id), [users]);
-  const effectiveSelectedReaders = useMemo(
-    () => (filters.readers.length > 0 ? filters.readers : allReaderIds),
-    [filters.readers, allReaderIds],
-  );
+  const effectiveSelectedReaders = useMemo(() => {
+    const base = filters.readers.length > 0 ? filters.readers : allReaderIds;
+    if (lockedReaderId && !base.includes(lockedReaderId)) {
+      return [lockedReaderId, ...base];
+    }
+    return base;
+  }, [filters.readers, allReaderIds, lockedReaderId]);
+
+  const needsExtraReader = useMemo(() => {
+    if (filters.view !== "joint" || !lockedReaderId) return false;
+    if (filters.readers.length === 0) return false;
+    return filters.readers.filter((id) => id !== lockedReaderId).length === 0;
+  }, [filters.view, filters.readers, lockedReaderId]);
 
   const booksQueryData = useMemo(() => {
     if (!rawBooks?.data) return rawBooks;
@@ -442,6 +462,8 @@ export function useHome() {
 
   const handleToggleReader = useCallback(
     (readerId: string) => {
+      if (readerId === lockedReaderId) return;
+
       const defaultReaders = isAllBooksActive
         ? defaultTodosReaders
         : allReaderIds;
@@ -464,6 +486,7 @@ export function useHome() {
       isAllBooksActive,
       defaultTodosReaders,
       effectiveTodosReaders,
+      lockedReaderId,
     ],
   );
 
@@ -579,5 +602,7 @@ export function useHome() {
     isLoggedIn,
     users,
     readers,
+    lockedReaderId,
+    needsExtraReader,
   };
 }

--- a/src/modules/home/index.tsx
+++ b/src/modules/home/index.tsx
@@ -55,6 +55,8 @@ export default function ClientHome() {
     isLoggedIn,
     checkIsUserActive,
     readers,
+    lockedReaderId,
+    needsExtraReader,
   } = useHome();
 
   const dialogModal = useModal();
@@ -206,26 +208,55 @@ export default function ClientHome() {
                         </Button>
                       )}
                     </div>
-                    <div className="flex gap-2 items-start justify-start w-full">
+                    <div className="flex flex-col gap-1.5 items-start justify-start w-full">
                       {!isMyBooksActive && (
-                        <div className="flex gap-2">
-                          {readers.map((user) => (
-                            <Button
-                              key={user.id}
-                              size="sm"
-                              variant="outline"
-                              onClick={() => handleToggleReader(user.id)}
-                              className={cn(
-                                "rounded-full h-8 px-3 text-xs font-medium transition-all",
-                                checkIsUserActive(user.id)
-                                  ? "bg-violet-600 border-violet-600 text-white hover:bg-violet-700"
-                                  : "border-zinc-200 text-zinc-500 hover:border-violet-200 hover:text-violet-600 dark:border-zinc-800",
+                        <>
+                          <div className="flex flex-wrap gap-2">
+                            {readers.map((reader) => {
+                              const isLocked = reader.id === lockedReaderId;
+                              const isActive = checkIsUserActive(reader.id);
+                              return (
+                                <Button
+                                  key={reader.id}
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => handleToggleReader(reader.id)}
+                                  disabled={isLocked}
+                                  aria-pressed={isActive}
+                                  aria-label={
+                                    isLocked
+                                      ? `${reader.display_name} (sempre incluído nesta visão)`
+                                      : reader.display_name
+                                  }
+                                  className={cn(
+                                    "rounded-full h-8 px-3 text-xs font-medium transition-all",
+                                    isActive
+                                      ? "bg-violet-600 border-violet-600 text-white hover:bg-violet-700"
+                                      : "border-zinc-200 text-zinc-500 hover:border-violet-200 hover:text-violet-600 dark:border-zinc-800",
+                                    isLocked &&
+                                      "opacity-100 cursor-not-allowed disabled:opacity-100 disabled:pointer-events-none",
+                                  )}
+                                >
+                                  {reader.display_name}
+                                </Button>
+                              );
+                            })}
+                          </div>
+
+                          {lockedReaderId && (
+                            <p className="text-[10px] text-zinc-400 dark:text-zinc-500 leading-snug">
+                              {needsExtraReader ? (
+                                <span className="text-amber-500 dark:text-amber-400 font-medium">
+                                  Selecione pelo menos outro(a) leitor(a) para ver leituras conjuntas.
+                                </span>
+                              ) : !isAllBooksActive ? (
+                                "Você é sempre incluído. Selecione pelo menos outro(a) leitor(a) além de você."
+                              ) : (
+                                "Você é sempre incluído. Adicione ou remova outros leitores livremente."
                               )}
-                            >
-                              {user.display_name}
-                            </Button>
-                          ))}
-                        </div>
+                            </p>
+                          )}
+                        </>
                       )}
                     </div>
                   </div>

--- a/src/services/books/books.mapper.test.ts
+++ b/src/services/books/books.mapper.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { BookMapper } from "./books.mapper";
+
+describe("BookMapper.isSoloBook", () => {
+  it("retorna true quando readers tem 1 elemento igual a chosen_by", () => {
+    expect(
+      BookMapper.isSoloBook({ readerIds: ["user-a"], chosen_by: "user-a" }),
+    ).toBe(true);
+  });
+
+  it("retorna false quando readers tem múltiplos elementos", () => {
+    expect(
+      BookMapper.isSoloBook({
+        readerIds: ["user-a", "user-b"],
+        chosen_by: "user-a",
+      }),
+    ).toBe(false);
+  });
+
+  it("retorna false quando readers é vazio", () => {
+    expect(
+      BookMapper.isSoloBook({ readerIds: [], chosen_by: "user-a" }),
+    ).toBe(false);
+  });
+
+  it("retorna false quando readers tem 1 elemento diferente de chosen_by", () => {
+    expect(
+      BookMapper.isSoloBook({ readerIds: ["user-a"], chosen_by: "user-b" }),
+    ).toBe(false);
+  });
+
+  it("retorna false quando chosen_by é string vazia", () => {
+    expect(
+      BookMapper.isSoloBook({ readerIds: ["user-a"], chosen_by: "" }),
+    ).toBe(false);
+  });
+
+  it("retorna false quando readers tem 1 elemento mas chosen_by é string vazia", () => {
+    expect(
+      BookMapper.isSoloBook({ readerIds: [""], chosen_by: "" }),
+    ).toBe(true);
+  });
+
+  it("diferencia UUIDs com case diferente como distintos (sem normalização)", () => {
+    expect(
+      BookMapper.isSoloBook({
+        readerIds: ["USER-A"],
+        chosen_by: "user-a",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/services/books/books.mapper.ts
+++ b/src/services/books/books.mapper.ts
@@ -48,6 +48,10 @@ export class BookMapper {
     };
   }
 
+  static isSoloBook(book: Pick<BookDomain, "readerIds" | "chosen_by">): boolean {
+    return book.readerIds.length === 1 && book.readerIds[0] === book.chosen_by;
+  }
+
   static enrichReadersDisplay(book: BookDomain, users: UserLookup[]): BookDomain {
     const ids = book.readerIds ?? [];
     return {

--- a/supabase/migrations/20260421_books_privacy_solo_reader.sql
+++ b/supabase/migrations/20260421_books_privacy_solo_reader.sql
@@ -1,0 +1,21 @@
+-- RN56: Livros individuais (readers=[X] AND chosen_by=X) são visíveis apenas ao próprio dono.
+-- Substitui books_select_all (USING true) por policy com filtro de privacidade solo.
+--
+-- Lógica (De Morgan): visível quando NOT(é_solo) OR (é_o_dono)
+--   - Livros com múltiplos leitores: NOT(solo)=TRUE → visível para todos (incluindo anon).
+--   - Livros solo: NOT(solo)=FALSE → visível apenas quando chosen_by = auth.uid().
+--   - COALESCE garante que readers NULL (não deve ocorrer, mas schema usa COALESCE em outras policies)
+--     seja tratado como array vazio → array_length=NULL → NOT(solo)=TRUE → visível (comportamento seguro).
+
+DROP POLICY IF EXISTS books_select_all ON public.books;
+
+CREATE POLICY books_select_non_solo_or_owner
+  ON public.books
+  FOR SELECT
+  USING (
+    NOT (
+      array_length(COALESCE(readers, ARRAY[]::uuid[]), 1) = 1
+      AND (COALESCE(readers, ARRAY[]::uuid[]))[1] = chosen_by
+    )
+    OR chosen_by = auth.uid()
+  );


### PR DESCRIPTION
## Summary by Sourcery

Enforce privacy for solo reader books and make the logged-in user an immutable, required reader in home filters for Todos and Joint views.

New Features:
- Mark the logged-in user as a locked reader in Todos and Joint views, automatically injecting their ID into reader filters and derived queries.
- Display a 'Privado' badge on book cards for solo books owned by the current user to indicate private visibility.

Enhancements:
- Add a BookMapper helper to detect solo books and expose this state through the book card hook.
- Extend the home hook to expose lockedReaderId and needsExtraReader, and update the home page reader chips and messaging to reflect the locked reader behavior and joint-reading requirement.

Deployment:
- Introduce a Supabase migration that replaces the open books SELECT policy with a privacy-aware policy that hides solo books from everyone except their owner, including anonymous users.

Documentation:
- Document new business rules for solo-book privacy and mandatory reader behavior (RN56 and RN57), and clarify how they interact with existing visibility and visitor rules.

Tests:
- Add unit tests for the home hook to cover lockedReaderId behavior, reader toggling constraints, and the needsExtraReader flag.
- Add unit tests around the book mapper's solo-book detection logic.