### PR TITLE
Fix locked joint reader chip state

### DIFF
--- a/src/modules/home/hooks/useHome.test.ts
+++ b/src/modules/home/hooks/useHome.test.ts
@@ -119,6 +119,8 @@ function setupHook(
 describe("useHome", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    (useIsLoggedIn as unknown as Mock).mockReturnValue(false);
+    (useUserStore as unknown as Mock).mockReturnValue(null);
     (useUser as Mock).mockReturnValue({
       users: [],
       isLoadingUsers: false,
@@ -902,6 +904,24 @@ describe("useHome", () => {
       });
 
       const { result } = setupHook({ readers: [], view: "joint" });
+      expect(result.current.checkIsUserActive("1")).toBe(true);
+      expect(result.current.checkIsUserActive("2")).toBe(true);
+    });
+
+    it("marks locked reader as active in joint view when omitted from URL readers", () => {
+      (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
+      (useUserStore as unknown as Mock).mockReturnValue({
+        id: "1",
+        display_name: "Matheus",
+      });
+      (useUser as Mock).mockReturnValue({
+        users: mockUsers,
+        isLoadingUsers: false,
+      });
+
+      const { result } = setupHook({ readers: ["2"], view: "joint" });
+
+      expect(result.current.lockedReaderId).toBe("1");
       expect(result.current.checkIsUserActive("1")).toBe(true);
       expect(result.current.checkIsUserActive("2")).toBe(true);
     });

--- a/src/modules/home/hooks/useHome.ts
+++ b/src/modules/home/hooks/useHome.ts
@@ -498,13 +498,14 @@ export function useHome() {
         return effectiveTodosReaders.includes(readerId);
       }
 
-      if (filters.readers.length === 0) {
-        return true;
-      }
-
-      return filters.readers.includes(readerId);
+      return effectiveSelectedReaders.includes(readerId);
     },
-    [filters.readers, isMyBooksActive, isAllBooksActive, effectiveTodosReaders],
+    [
+      isMyBooksActive,
+      isAllBooksActive,
+      effectiveTodosReaders,
+      effectiveSelectedReaders,
+    ],
   );
 
   const { activeStatuses, handleToggleStatus } = useStatusFilters({

--- a/src/modules/home/index.test.tsx
+++ b/src/modules/home/index.test.tsx
@@ -46,6 +46,8 @@ const { baseUseHome } = vi.hoisted(() => ({
     isLoggedIn: true,
     checkIsUserActive: vi.fn(() => false),
     readers: [],
+    lockedReaderId: undefined,
+    needsExtraReader: false,
   },
 }));
 
@@ -72,6 +74,36 @@ vi.mock("@/hooks", async (importOriginal) => {
       setIsOpen: mockSetBookFormOpen,
     })),
   };
+  it("renders the locked reader chip as active and disabled in joint view", () => {
+    vi.mocked(useHome).mockReturnValueOnce({
+      ...baseUseHome,
+      filters: {
+        readers: ["2"],
+        status: [],
+        gender: [],
+        view: "joint",
+        year: undefined,
+      },
+      isAllBooksActive: false,
+      readers: [
+        { id: "1", display_name: "Matheus" },
+        { id: "2", display_name: "Barbara" },
+      ],
+      lockedReaderId: "1",
+      checkIsUserActive: vi.fn((readerId: string) =>
+        ["1", "2"].includes(readerId),
+      ),
+    } as unknown as ReturnType<typeof useHome>);
+
+    render(<ClientHome />);
+
+    const lockedChip = screen.getByRole("button", {
+      name: "Matheus (sempre incluÃ­do nesta visÃ£o)",
+    });
+
+    expect(lockedChip).toBeDisabled();
+    expect(lockedChip).toHaveAttribute("aria-pressed", "true");
+  });
 });
 
 vi.mock("@/modules/bookUpsert", () => ({

--- a/src/services/books/books.mapper.test.ts
+++ b/src/services/books/books.mapper.test.ts
@@ -23,6 +23,10 @@ describe("BookMapper.isSoloBook", () => {
     ).toBe(false);
   });
 
+  it("retorna false quando readers é undefined", () => {
+    expect(BookMapper.isSoloBook({ chosen_by: "user-a" })).toBe(false);
+  });
+
   it("retorna false quando readers tem 1 elemento diferente de chosen_by", () => {
     expect(
       BookMapper.isSoloBook({ readerIds: ["user-a"], chosen_by: "user-b" }),

--- a/src/services/books/books.mapper.ts
+++ b/src/services/books/books.mapper.ts
@@ -48,8 +48,13 @@ export class BookMapper {
     };
   }
 
-  static isSoloBook(book: Pick<BookDomain, "readerIds" | "chosen_by">): boolean {
-    return book.readerIds.length === 1 && book.readerIds[0] === book.chosen_by;
+  static isSoloBook(
+    book: Pick<BookDomain, "chosen_by"> & {
+      readerIds?: BookDomain["readerIds"] | null;
+    },
+  ): boolean {
+    const readerIds = book.readerIds ?? [];
+    return readerIds.length === 1 && readerIds[0] === book.chosen_by;
   }
 
   static enrichReadersDisplay(book: BookDomain, users: UserLookup[]): BookDomain {


### PR DESCRIPTION
## Summary by Sourcery

Ensure locked readers remain active and correctly reflected in joint view selection while hardening solo book detection against missing reader data.

Bug Fixes:
- Fix locked reader selection so the locked reader stays active in joint view even when omitted from URL filters.
- Prevent isSoloBook from throwing or misclassifying books when readerIds is undefined or null.

Enhancements:
- Refine reader activity computation to rely on the effective selected readers set instead of raw filter values.

Tests:
- Add home page test asserting the locked reader chip is rendered as active and disabled in joint view.
- Extend useHome hook tests to cover locked reader behavior when URL filters omit the locked reader.
- Add a BookMapper.isSoloBook test verifying behavior when readerIds is undefined.