### PR TITLE
feat: novo genero

### DIFF
--- a/src/components/bookCard/hooks/useBookCard.test.ts
+++ b/src/components/bookCard/hooks/useBookCard.test.ts
@@ -3,6 +3,7 @@ import { Mock, vi } from "vitest";
 import { useBookCard } from "./useBookCard";
 import { BookDomain } from "@/types/books.types";
 import { useRouter } from "next/navigation";
+import { BookService } from "@/services/books/books.service";
 
 vi.mock("next/navigation", () => ({ useRouter: vi.fn() }));
 vi.mock("@/services/books/books.service");
@@ -157,6 +158,29 @@ describe("useBookCard", () => {
         await expect(
           result.current.handleConfirmDelete("1"),
         ).rejects.toThrow(/shelfId é obrigatório/);
+      });
+
+      it("when not shelf, deletes book and replaces route with home listing", async () => {
+        const replaceMock = vi.fn();
+        (useRouter as Mock).mockReturnValue({
+          push: vi.fn(),
+          replace: replaceMock,
+        });
+        const deleteMock = vi.fn().mockResolvedValue(undefined);
+        vi.mocked(BookService).mockImplementation(
+          class MockBookService {
+            delete = deleteMock;
+          } as unknown as typeof BookService,
+        );
+
+        const { result } = renderBookCardHook();
+
+        await act(async () => {
+          await result.current.handleConfirmDelete("1");
+        });
+
+        expect(deleteMock).toHaveBeenCalledWith("1");
+        expect(replaceMock).toHaveBeenCalledWith("/");
       });
     });
 

--- a/src/components/bookCard/hooks/useBookCard.ts
+++ b/src/components/bookCard/hooks/useBookCard.ts
@@ -153,6 +153,7 @@ export function useBookCard({
       if (!isShelf) {
         const service = new BookService();
         await service.delete(id);
+        router.replace("/");
         return;
       }
       if (!shelfId) {
@@ -164,7 +165,7 @@ export function useBookCard({
       await service.removeBookFromShelf(shelfId, id);
       window.location.reload();
     },
-    [isShelf, shelfId],
+    [isShelf, shelfId, router],
   );
 
   return {

--- a/src/constants/genders.ts
+++ b/src/constants/genders.ts
@@ -1,10 +1,11 @@
 export const genders = [
   { label: "Romance", value: "romance" },
-  { label: "Romance de época", value: "historical_romance" },
+  { label: "Romance de época", value: "time_romance" },
   {
     label: "Romance contemporâneo",
     value: "contemporary_romance",
   },
+  { label: "Romance histórico", value: "historical_romance" },
   { label: "Fantasia", value: "fantasy" },
   { label: "Romantasia", value: "romantasy" },
   { label: "Realismo mágico", value: "magical_realism" },
@@ -32,7 +33,8 @@ export const getGenderLabel = (value: string | undefined) => {
 
 export const genreColorMap: Record<string, string> = {
   romance: "bg-violet-400 text-white",
-  historical_romance: "bg-fuchsia-300 text-white",
+  time_romance: "bg-fuchsia-300 text-white",
+  historical_romance: "bg-pink-300 text-white",
   contemporary_romance: "bg-purple-500 text-white",
 
   fantasy: "bg-yellow-700 text-white",

--- a/src/modules/home/components/filtersSheet/filters.tsx
+++ b/src/modules/home/components/filtersSheet/filters.tsx
@@ -49,11 +49,9 @@ export default function FiltersSheet({
   }, [localFilters, searchQuery, updateUrlWithFilters, setIsOpen]);
 
   const handleCancel = useCallback(() => {
-    const cleared = { ...filters, readers: [], gender: [], status: [], isReread: undefined };
+    resetLocalFilters(filters);
     setIsOpen(false);
-    updateUrlWithFilters(cleared, "");
-    resetLocalFilters(cleared);
-  }, [filters, setIsOpen, updateUrlWithFilters, resetLocalFilters]);
+  }, [filters, setIsOpen, resetLocalFilters]);
 
   const handleClearAll = useCallback(() => {
     const cleared = { ...localFilters, readers: [], gender: [], status: [], isReread: undefined };

--- a/src/modules/home/hooks/useHome.test.ts
+++ b/src/modules/home/hooks/useHome.test.ts
@@ -908,6 +908,49 @@ describe("useHome", () => {
       expect(result.current.checkIsUserActive("2")).toBe(true);
     });
 
+    it("em joint com URL vazia, o default de toggles segue a rede (readers), não todo o array users", () => {
+      (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
+      (useUserStore as unknown as Mock).mockReturnValue({
+        id: "1",
+        display_name: "Matheus",
+      });
+      (useUser as Mock).mockReturnValue({
+        users: [
+          ...mockUsers,
+          { id: "3", display_name: "Nao Seguido" },
+        ],
+        isLoadingUsers: false,
+      });
+      (useQuery as Mock).mockImplementation(
+        (params: { queryKey?: unknown[] }) => {
+          if (params?.queryKey?.[0] === "userSocial") {
+            return {
+              data: ["2"],
+              isLoading: false,
+              isFetching: false,
+              isFetched: true,
+              isError: false,
+            };
+          }
+          return {
+            data: { data: [], total: 0 },
+            isFetching: false,
+            isFetched: true,
+            isError: false,
+          };
+        },
+      );
+
+      const { result } = setupHook({ readers: [], view: "joint" });
+      expect(result.current.readers.map((r) => r.id)).toEqual(["1", "2"]);
+
+      act(() => result.current.handleToggleReader("2"));
+
+      expect(mockUpdateUrlWithFilters).toHaveBeenCalledWith(
+        expect.objectContaining({ readers: ["1"], view: "joint" }),
+      );
+    });
+
     it("marks locked reader as active in joint view when omitted from URL readers", () => {
       (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
       (useUserStore as unknown as Mock).mockReturnValue({

--- a/src/modules/home/hooks/useHome.ts
+++ b/src/modules/home/hooks/useHome.ts
@@ -149,9 +149,9 @@ export function useHome() {
     };
   }, [filters.readers, readers, isMyBooksActive]);
 
-  const isAwaitingSpecificBook = useMemo(
-    () => !!(filters.bookId || searchQuery),
-    [filters.bookId, searchQuery],
+  const shouldThrowSyncOnEmpty = useMemo(
+    () => !!searchQuery.trim() && !filters.bookId?.trim(),
+    [searchQuery, filters.bookId],
   );
 
   const effectiveUserId = isMyBooksActive ? user!.id : undefined;
@@ -234,7 +234,7 @@ export function useHome() {
         });
 
         if (
-          isAwaitingSpecificBook &&
+          shouldThrowSyncOnEmpty &&
           (!response || response.data?.length === 0)
         ) {
           throw new Error("Sincronizando novo livro...");
@@ -260,18 +260,10 @@ export function useHome() {
         pageSize: serverPageSize,
       });
 
-      if (
-        isLoggedIn &&
-        isAwaitingSpecificBook &&
-        (!response || response.data?.length === 0)
-      ) {
-        throw new Error("Sincronizando novo livro...");
-      }
-
       return response;
     },
     retry: (failureCount) => {
-      if (isLoggedIn && isAwaitingSpecificBook && failureCount < 2) {
+      if (isLoggedIn && shouldThrowSyncOnEmpty && failureCount < 2) {
         return true;
       }
       return false;
@@ -298,13 +290,24 @@ export function useHome() {
   const formattedYear = useMemo(() => formatYear(filters.year), [filters.year]);
 
   const allReaderIds = useMemo(() => users.map((u) => u.id), [users]);
+  const networkReaderIds = useMemo(
+    () => readers.map((u) => u.id),
+    [readers],
+  );
   const effectiveSelectedReaders = useMemo(() => {
-    const base = filters.readers.length > 0 ? filters.readers : allReaderIds;
+    const defaultWhenEmpty = isAllBooksActive ? allReaderIds : networkReaderIds;
+    const base = filters.readers.length > 0 ? filters.readers : defaultWhenEmpty;
     if (lockedReaderId && !base.includes(lockedReaderId)) {
       return [lockedReaderId, ...base];
     }
     return base;
-  }, [filters.readers, allReaderIds, lockedReaderId]);
+  }, [
+    filters.readers,
+    allReaderIds,
+    networkReaderIds,
+    isAllBooksActive,
+    lockedReaderId,
+  ]);
 
   const needsExtraReader = useMemo(() => {
     if (filters.view !== "joint" || !lockedReaderId) return false;
@@ -466,7 +469,7 @@ export function useHome() {
 
       const defaultReaders = isAllBooksActive
         ? defaultTodosReaders
-        : allReaderIds;
+        : networkReaderIds;
       const currentReaders = isAllBooksActive
         ? effectiveTodosReaders
         : filters.readers.length > 0
@@ -482,11 +485,11 @@ export function useHome() {
     [
       filters,
       updateUrlWithFilters,
-      allReaderIds,
       isAllBooksActive,
       defaultTodosReaders,
       effectiveTodosReaders,
       lockedReaderId,
+      networkReaderIds,
     ],
   );
 
@@ -527,12 +530,16 @@ export function useHome() {
     if (!isMyBooksActive) return;
 
     queryClient.prefetchQuery({
-      queryKey: QUERY_KEYS.books.list(
-        serverFilters,
-        searchQuery,
-        nextPage,
-        effectiveUserId,
-      ),
+      queryKey: [
+        ...QUERY_KEYS.books.list(
+          serverFilters,
+          searchQuery,
+          nextPage,
+          effectiveUserId,
+        ),
+        "relationship",
+        relationshipKey,
+      ],
       queryFn: () =>
         bookService.getAll({
           bookId: serverFilters.bookId,
@@ -556,6 +563,7 @@ export function useHome() {
     allBooks?.total,
     currentPage,
     effectiveUserId,
+    relationshipKey,
     relationshipUserValues,
     serverFilters,
     isMyBooksActive,

--- a/src/modules/home/hooks/useSyncLocalStateOnClose.test.ts
+++ b/src/modules/home/hooks/useSyncLocalStateOnClose.test.ts
@@ -94,3 +94,23 @@ describe("useSyncLocalStateOnClose", () => {
     expect(syncLocalState).toHaveBeenCalledWith("date_desc");
   });
 });
+
+describe("areFiltersOptionsEqual", () => {
+  it("retorna false quando só isReread difere", () => {
+    const a: FiltersOptions = { ...baseFilters, isReread: true };
+    const b: FiltersOptions = { ...baseFilters, isReread: false };
+    expect(areFiltersOptionsEqual(a, b)).toBe(false);
+  });
+
+  it("retorna false quando só sort difere", () => {
+    const a: FiltersOptions = { ...baseFilters, sort: "pages_asc" };
+    const b: FiltersOptions = { ...baseFilters, sort: "pages_desc" };
+    expect(areFiltersOptionsEqual(a, b)).toBe(false);
+  });
+
+  it("trata undefined e ausência de sort como iguais", () => {
+    const a: FiltersOptions = { ...baseFilters };
+    const b: FiltersOptions = { ...baseFilters, sort: undefined };
+    expect(areFiltersOptionsEqual(a, b)).toBe(true);
+  });
+});

--- a/src/modules/home/hooks/useSyncLocalStateOnClose.ts
+++ b/src/modules/home/hooks/useSyncLocalStateOnClose.ts
@@ -28,7 +28,9 @@ export const areFiltersOptionsEqual = (
   previous.bookId === current.bookId &&
   previous.authorId === current.authorId &&
   previous.year === current.year &&
-  previous.myBooks === current.myBooks;
+  previous.myBooks === current.myBooks &&
+  previous.isReread === current.isReread &&
+  previous.sort === current.sort;
 
 export const useSyncLocalStateOnClose = <T>({
   externalState,

--- a/src/modules/home/index.tsx
+++ b/src/modules/home/index.tsx
@@ -411,7 +411,11 @@ export default function ClientHome() {
           renderItem={(book) => (
             <BookCard key={book.id} book={book} isShelf={false} />
           )}
-          emptyMessage="Nenhum livro encontrado para os filtros selecionados."
+          emptyMessage={
+            filters.bookId?.trim()
+              ? "Não encontramos um livro com este identificador na sua lista."
+              : "Nenhum livro encontrado para os filtros selecionados."
+          }
           isError={isError}
         />
       )}


### PR DESCRIPTION
## Summary by Sourcery

Adjust home listing behavior, filters, and book deletion flow while adding support for a new romance genre variant.

New Features:
- Add a new "Romance histórico" genre with its own display label and color mapping.
- Customize the empty-state message on the home listing when searching by specific book identifier.

Bug Fixes:
- Ensure joint view reader toggles default to the user’s network instead of all users when URL readers are empty.
- Avoid unnecessary sync messaging by tightening the condition that triggers sync errors to only search queries without explicit book IDs.
- Include reread and sort fields when comparing filter options to detect changes correctly.
- Reset local filter state on cancel without mutating URL filters or clearing readers and gender/status selections unintentionally.
- Redirect back to the home listing after deleting a non-shelf book.

Enhancements:
- Differentiate color badges for time-based romance and historical romance genres.
- Scope home book list prefetching by relationship key to align cache entries with the current relationship context.

Tests:
- Add coverage for joint view reader defaults based on the social network.
- Add tests for the filter comparison helper to validate reread and sort handling.
- Add a test ensuring that deleting a non-shelf book redirects back to the home page.