### PR TITLE
feat(home): restringe visão Todos ao usuário logado e remove chips

### DIFF
--- a/BUSINESS_RULES.md
+++ b/BUSINESS_RULES.md
@@ -152,13 +152,8 @@ As regras abaixo são aplicadas no banco (Row Level Security). A UI continua res
   - O `BookCard` exibe um badge "Privado" (ícone de cadeado) quando `isSoloBook(book) && book.chosen_by === user.id`.
   - Livros com múltiplos leitores **ou** com `readers[1] ≠ chosen_by` permanecem com visibilidade pública inalterada.
 
-- **RN57 - Leitor obrigatório nas visões "Todos" e "Leitura em conjunto":** Quando o usuário está logado e visualiza as visões **Todos** (`view="todos"`) ou **Leitura em conjunto** (`view="joint"`):
-  - O chip do próprio usuário no filtro de leitores fica **sempre marcado e desabilitado** (`disabled`).
-  - Clicar no chip do próprio usuário não tem efeito (bloqueado em `handleToggleReader`).
-  - O `aria-label` do chip indica "sempre incluído nesta visão".
-  - Mesmo que a URL contenha `readers` sem o ID do usuário logado, os memos `effectiveTodosReaders` (visão Todos) e `effectiveSelectedReaders` (visão Joint) injetam o ID de volta automaticamente.
-  - **Distinção por visão:**
-    - `todos`: não exige leitores adicionais; o usuário pode navegar sozinho.
-    - `joint`: exige **pelo menos 1 outro leitor** além do usuário logado (`needsExtraReader = true` quando apenas o próprio ID está selecionado); mensagem de aviso exibida na UI em âmbar.
-  - A regra não se aplica em `myBooks` (chips de leitor não são exibidos nessa visão).
-  - A regra não se aplica para usuários não logados (`lockedReaderId = undefined`).
+- **RN57 - Filtro de leitores por visão (Todos vs Leitura em conjunto):**
+  - **Todos** (`view="todos"`): com usuário logado, a lista usa **apenas o próprio usuário** como escopo (`relationshipUserValues`); não há chips de leitor nem aviso de inclusão na home; o sheet de filtros não mostra a seção "Leitores" (exceto quando `myBooks` está ativo); `handleToggleReader` não altera a URL nesta visão.
+  - **Leitura em conjunto** (`view="joint"`), usuário logado: o chip do próprio usuário fica **sempre marcado e desabilitado** (`disabled`); clicar nele não tem efeito (`handleToggleReader`); `aria-label` com "sempre incluído nesta visão"; se a URL tiver `readers` sem o ID do usuário, os memos reinjetam o ID; exige **pelo menos 1 outro leitor** (`needsExtraReader`) com mensagem de aviso em âmbar quando faltar.
+  - Em **myBooks** continuam sem chips de leitor na home.
+  - Usuário não logado: `lockedReaderId = undefined`; lock só existe em `joint` quando logado.

--- a/src/modules/home/components/filtersSheet/filters.tsx
+++ b/src/modules/home/components/filtersSheet/filters.tsx
@@ -73,15 +73,16 @@ export default function FiltersSheet({
         </SheetHeader>
 
         <div className="flex flex-col gap-6 p-3 overflow-y-auto mt-4">
-          {pathname === "/" && (
-            <FilterSection
-              title="Leitores"
-              options={readerOptions}
-              selected={localFilters.readers}
-              onChange={(values) => handleFilterChange("readers", values)}
-              placeholder="Selecione os leitores"
-            />
-          )}
+          {pathname === "/" &&
+            !(localFilters.view === "todos" && !localFilters.myBooks) && (
+              <FilterSection
+                title="Leitores"
+                options={readerOptions}
+                selected={localFilters.readers}
+                onChange={(values) => handleFilterChange("readers", values)}
+                placeholder="Selecione os leitores"
+              />
+            )}
 
           <FilterSection
             title="Status"

--- a/src/modules/home/hooks/useHome.test.ts
+++ b/src/modules/home/hooks/useHome.test.ts
@@ -105,6 +105,19 @@ function mockQueryData(total: number, followingIds: string[] = []) {
     });
 }
 
+function lastBooksListRelationshipKey(): string | undefined {
+  const calls = (useQuery as Mock).mock.calls;
+  for (let i = calls.length - 1; i >= 0; i--) {
+    const queryKey = calls[i]?.[0]?.queryKey as unknown[] | undefined;
+    if (!Array.isArray(queryKey) || queryKey[0] !== "books") continue;
+    const relIdx = queryKey.indexOf("relationship");
+    if (relIdx !== -1 && relIdx + 1 < queryKey.length) {
+      return String(queryKey[relIdx + 1]);
+    }
+  }
+  return undefined;
+}
+
 function setupHook(
   filtersOverride: Partial<FiltersOptions> = {},
   searchQuery = "",
@@ -286,7 +299,7 @@ describe("useHome", () => {
       );
     });
 
-    it("usa relacionamento baseado em usuário atual + seguidos na query key", () => {
+    it("usa apenas o usuário logado na query key da visão Todos", () => {
       (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
       (useUserStore as unknown as Mock).mockReturnValue({
         id: "1",
@@ -302,7 +315,7 @@ describe("useHome", () => {
 
       expect(useQuery).toHaveBeenCalledWith(
         expect.objectContaining({
-          queryKey: expect.arrayContaining(["relationship", "1|2"]),
+          queryKey: expect.arrayContaining(["relationship", "1"]),
         }),
       );
     });
@@ -340,7 +353,7 @@ describe("useHome", () => {
   });
 
   describe('"Todos" reader selection behavior', () => {
-    it("marks current user and followed users as active by default in Todos", () => {
+    it("mantém apenas o usuário atual na seleção efetiva da visão Todos", () => {
       (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
       (useUserStore as unknown as Mock).mockReturnValue({
         id: "1",
@@ -355,10 +368,10 @@ describe("useHome", () => {
       const { result } = setupHook({ view: "todos", readers: [] });
 
       expect(result.current.checkIsUserActive("1")).toBe(true);
-      expect(result.current.checkIsUserActive("2")).toBe(true);
+      expect(result.current.checkIsUserActive("2")).toBe(false);
     });
 
-    it("adds additional readers in Todos when user toggles chips", () => {
+    it("não altera a URL ao alternar leitor na visão Todos", () => {
       (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
       (useUserStore as unknown as Mock).mockReturnValue({
         id: "1",
@@ -373,12 +386,10 @@ describe("useHome", () => {
 
       act(() => result.current.handleToggleReader("2"));
 
-      expect(mockUpdateUrlWithFilters).toHaveBeenCalledWith(
-        expect.objectContaining({ readers: ["1", "2"] }),
-      );
+      expect(mockUpdateUrlWithFilters).not.toHaveBeenCalled();
     });
 
-    it("limita leitores visíveis na visão Todos para usuário atual e seguidos", () => {
+    it("na visão Todos só lista o usuário logado como opção de leitor", () => {
       (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
       (useUserStore as unknown as Mock).mockReturnValue({
         id: "1",
@@ -392,10 +403,10 @@ describe("useHome", () => {
 
       const { result } = setupHook({ view: "todos", readers: [] });
 
-      expect(result.current.readers.map((r) => r.id)).toEqual(["1", "2"]);
+      expect(result.current.readers.map((r) => r.id)).toEqual(["1"]);
     });
 
-    it("changes query key when Todos readers selection changes", () => {
+    it("na visão Todos a relationship key permanece só com o usuário mesmo se readers na URL mudar", () => {
       (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
       (useUserStore as unknown as Mock).mockReturnValue({
         id: "1",
@@ -433,16 +444,14 @@ describe("useHome", () => {
       );
       const { rerender } = renderHook(() => useHome());
 
-      const firstCall = (useQuery as Mock).mock.calls.at(-1)?.[0]?.queryKey;
+      expect(lastBooksListRelationshipKey()).toBe("1");
 
       (useFiltersUrl as Mock).mockReturnValue(
         buildFiltersUrlReturn({ view: "todos", readers: ["2"] }),
       );
       rerender();
 
-      const secondCall = (useQuery as Mock).mock.calls.at(-1)?.[0]?.queryKey;
-
-      expect(JSON.stringify(firstCall)).not.toBe(JSON.stringify(secondCall));
+      expect(lastBooksListRelationshipKey()).toBe("1");
     });
   });
 
@@ -677,7 +686,7 @@ describe("useHome", () => {
       expect(result.current.lockedReaderId).toBeUndefined();
     });
 
-    it("é o user.id quando logado na visão todos", () => {
+    it("é undefined quando logado na visão todos", () => {
       (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
       (useUserStore as unknown as Mock).mockReturnValue({
         id: "1",
@@ -685,7 +694,7 @@ describe("useHome", () => {
       });
 
       const { result } = setupHook({ view: "todos" });
-      expect(result.current.lockedReaderId).toBe("1");
+      expect(result.current.lockedReaderId).toBeUndefined();
     });
 
     it("é o user.id quando logado na visão joint", () => {
@@ -710,7 +719,7 @@ describe("useHome", () => {
       expect(result.current.lockedReaderId).toBeUndefined();
     });
 
-    it("handleToggleReader ignorado quando readerId === lockedReaderId (todos)", () => {
+    it("handleToggleReader não atualiza URL na visão todos", () => {
       (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
       (useUserStore as unknown as Mock).mockReturnValue({
         id: "1",
@@ -764,7 +773,7 @@ describe("useHome", () => {
       );
     });
 
-    it("effectiveTodosReaders injeta lockedReaderId quando ausente", () => {
+    it("visão Todos: query usa só o usuário logado mesmo se readers na URL citar outros", () => {
       (useIsLoggedIn as unknown as Mock).mockReturnValue(true);
       (useUserStore as unknown as Mock).mockReturnValue({
         id: "1",
@@ -783,7 +792,7 @@ describe("useHome", () => {
           (k: unknown) => typeof k === "string" && k.startsWith("1"),
         );
       expect(key).toContain("1");
-      expect(result.current.lockedReaderId).toBe("1");
+      expect(result.current.lockedReaderId).toBeUndefined();
     });
 
     it("effectiveSelectedReaders injeta lockedReaderId quando ausente na visão joint", () => {

--- a/src/modules/home/hooks/useHome.ts
+++ b/src/modules/home/hooks/useHome.ts
@@ -92,6 +92,8 @@ export function useHome() {
         scopeIds = [];
       } else if (filters.view === "seguindo") {
         scopeIds = followingIds;
+      } else if (filters.view === "todos") {
+        scopeIds = user?.id ? [user.id] : [];
       } else {
         scopeIds = allowedTodosReaderIds;
       }
@@ -136,7 +138,7 @@ export function useHome() {
 
   const lockedReaderId = useMemo(() => {
     if (!isLoggedIn || !user?.id || isMyBooksActive) return undefined;
-    if (filters.view === "todos" || filters.view === "joint") return user.id;
+    if (filters.view === "joint") return user.id;
     return undefined;
   }, [isLoggedIn, user?.id, isMyBooksActive, filters.view]);
 
@@ -182,8 +184,18 @@ export function useHome() {
     if (filters.view === "seguindo") {
       return isLoggedIn ? followingIds : ([] as string[]);
     }
+    if (filters.view === "todos") {
+      return isLoggedIn && user?.id ? [user.id] : allowedTodosReaderIds;
+    }
     return allowedTodosReaderIds;
-  }, [filters.myBooks, filters.view, isLoggedIn, followingIds, allowedTodosReaderIds]);
+  }, [
+    filters.myBooks,
+    filters.view,
+    isLoggedIn,
+    followingIds,
+    allowedTodosReaderIds,
+    user?.id,
+  ]);
 
   const effectiveScopedReaders = useMemo(() => {
     const scopedReaders = filters.readers.filter((id) =>
@@ -210,7 +222,10 @@ export function useHome() {
   const shouldWaitForUsers =
     !isMyBooksActive &&
     filters.readers.length === 0 &&
-    (isLoadingUsers || isLoadingFollowingIds);
+    (isLoadingUsers ||
+      (isLoadingFollowingIds &&
+        !isAllBooksActive &&
+        (filters.view === "seguindo" || filters.view === "joint")));
 
   const serverFilters = useMemo(
     () => ({ ...filters, readers: [] as string[] }),
@@ -533,6 +548,7 @@ export function useHome() {
 
   const handleToggleReader = useCallback(
     (readerId: string) => {
+      if (isAllBooksActive) return;
       if (readerId === lockedReaderId) return;
 
       const isScopedRelationshipView =

--- a/src/modules/home/index.tsx
+++ b/src/modules/home/index.tsx
@@ -240,7 +240,7 @@ export default function ClientHome() {
                       )}
                     </div>
                     <div className="flex flex-col gap-1.5 items-start justify-start w-full">
-                      {!isMyBooksActive && (
+                      {!isMyBooksActive && !isAllBooksActive && (
                         <>
                           <div className="flex flex-wrap gap-2">
                             {followingFeedEmpty ? (
@@ -304,10 +304,8 @@ export default function ClientHome() {
                                   Selecione pelo menos outro(a) leitor(a) para
                                   ver leituras conjuntas.
                                 </span>
-                              ) : !isAllBooksActive ? (
-                                "Você é sempre incluído. Selecione pelo menos outro(a) leitor(a) além de você."
                               ) : (
-                                "Você é sempre incluído. Adicione ou remova outros leitores livremente."
+                                "Você é sempre incluído. Selecione pelo menos outro(a) leitor(a) além de você."
                               )}
                             </p>
                           )}


### PR DESCRIPTION
Escopo da query e filtros usa apenas o próprio leitor em Todos; chips e avisos somem na home; sheet oculta Leitores em Todos; RN57 e testes atualizados.

Made-with: Cursor

## Summary by Sourcery

Restrict the home "Todos" view to use only the logged-in user as scope, hiding reader filters and chips there while updating related rules and tests.

Bug Fixes:
- Prevent URL and query key changes in the "Todos" view when toggling readers, ensuring the relationship scope stays bound to the logged-in user only.

Enhancements:
- Adjust home reader scoping so the "Todos" view always queries with only the current user, independent of URL readers, while keeping joint view behavior unchanged.
- Hide reader chips and the reader filter section on the home "Todos" view (except when My Books is active), and simplify the joint-view helper messaging logic.

Documentation:
- Update RN57 business rule documentation to describe the new reader behavior for the "Todos" and joint views, including the absence of reader chips and locked user in "Todos".

Tests:
- Update useHome tests to reflect the new "Todos" behavior around effective readers, relationship key scoping, URL updates, and lockedReaderId handling.