### PR TITLE
feat(collective-reading): comentários, curtidas e tela dedicada

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Gera os tipos do banco em `src/types/supabase.ts` a partir do projeto configurad
 - **Módulos de funcionalidade**
   - Local: `src/modules/<feature>/`.
   - Cada módulo concentra **componentes de tela**, **hooks**, **tipos** e, às vezes, **services específicos da feature**.
+  - Ex.: leitura coletiva em `src/modules/collectiveReading` (rota `(main)/collective-reading/...`, API `collective-reading-comments`).
 
 - **Serviços de domínio**
   - Exemplo: `src/services/books/` com:
@@ -177,6 +178,12 @@ Abaixo um mapa das principais telas e domínios da aplicação. Sempre que uma n
   - Cards por citação (`Card` + `CardDescription`).
   - Indicação de página (`quote.page`).
   - Esqueleton loading enquanto carrega.
+
+### 👥 Leitura coletiva (`/collective-reading/[id]/[title]`)
+
+- Espaço para livros com **mais de um leitor** em `readers`, acessível pelo link no `BookCard` (usuário logado e participante do livro).
+- Exibe o **próximo dia do cronograma** do usuário atual (primeira linha não concluída; se tudo concluído, último dia; sem cronograma, convite para criar em `/schedule/...`).
+- **Comentários** persistidos em `collective_reading_comments`; criação via `POST /api/collective-reading-comments` e remoção pelo autor via `DELETE /api/collective-reading-comments/[id]` (**RN59** no Obsidian). **Curtir / não curtir** por comentário: tabela `collective_reading_comment_reactions`, `POST /api/collective-reading-comment-reactions` (um voto por utilizador, comutável). Atualização **em tempo real** entre clientes via Supabase **Realtime** (`postgres_changes` em comentários e reações).
 
 ### 📅 Cronograma de Leitura (`/schedule/[id]/[title]`)
 

--- a/database.types.ts
+++ b/database.types.ts
@@ -154,6 +154,94 @@ export type Database = {
           },
         ]
       }
+      collective_reading_comments: {
+        Row: {
+          book_id: string
+          content: string
+          created_at: string
+          id: string
+          user_id: string
+        }
+        Insert: {
+          book_id: string
+          content: string
+          created_at?: string
+          id?: string
+          user_id: string
+        }
+        Update: {
+          book_id?: string
+          content?: string
+          created_at?: string
+          id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "collective_reading_comments_book_id_fkey"
+            columns: ["book_id"]
+            isOneToOne: false
+            referencedRelation: "books"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "collective_reading_comments_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      collective_reading_comment_reactions: {
+        Row: {
+          book_id: string
+          comment_id: string
+          created_at: string
+          id: string
+          reaction: string
+          user_id: string
+        }
+        Insert: {
+          book_id: string
+          comment_id: string
+          created_at?: string
+          id?: string
+          reaction: string
+          user_id: string
+        }
+        Update: {
+          book_id?: string
+          comment_id?: string
+          created_at?: string
+          id?: string
+          reaction?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "collective_reading_comment_reactions_book_id_fkey"
+            columns: ["book_id"]
+            isOneToOne: false
+            referencedRelation: "books"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "collective_reading_comment_reactions_comment_id_fkey"
+            columns: ["comment_id"]
+            isOneToOne: false
+            referencedRelation: "collective_reading_comments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "collective_reading_comment_reactions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       custom_shelf_books: {
         Row: {
           book_id: string | null

--- a/src/app/(main)/collective-reading/[id]/[title]/page.tsx
+++ b/src/app/(main)/collective-reading/[id]/[title]/page.tsx
@@ -1,0 +1,14 @@
+import ClientCollectiveReading from "@/modules/collectiveReading";
+import type { ClientCollectiveReadingProps } from "@/modules/collectiveReading/types/collectiveReading.types";
+
+export default async function CollectiveReadingPage({
+  params,
+}: {
+  params: Promise<ClientCollectiveReadingProps>;
+}) {
+  const { id, title: rawTitle } = await params;
+
+  const title = rawTitle ? decodeURIComponent(rawTitle) : "";
+
+  return <ClientCollectiveReading id={id} title={title} />;
+}

--- a/src/app/api/collective-reading-comment-reactions/route.test.ts
+++ b/src/app/api/collective-reading-comment-reactions/route.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+
+const COMMENT_ID = "550e8400-e29b-41d4-a716-446655440099";
+const BOOK_ID = "550e8400-e29b-41d4-a716-446655440001";
+const USER_ID = "660e8400-e29b-41d4-a716-446655440002";
+
+type Client = {
+  auth: { getUser: ReturnType<typeof vi.fn> };
+  from: ReturnType<typeof vi.fn>;
+};
+
+async function loadRoute(client: Client) {
+  vi.resetModules();
+  vi.doMock("@/lib/supabase/server", () => ({
+    createClient: vi.fn().mockResolvedValue(client),
+  }));
+  return import("./route");
+}
+
+describe("POST /api/collective-reading-comment-reactions", () => {
+  it("retorna 401 sem sessão", async () => {
+    const client: Client = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: null },
+          error: null,
+        }),
+      },
+      from: vi.fn(),
+    };
+    const route = await loadRoute(client);
+    const res = await route.POST(
+      new Request("http://localhost", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ commentId: COMMENT_ID, reaction: "like" }),
+      }),
+    );
+    expect(res.status).toBe(401);
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it("retorna 404 quando comentário não existe", async () => {
+    const maybeSingleComment = vi.fn().mockResolvedValue({
+      data: null,
+      error: null,
+    });
+    const selectComment = vi.fn(() => ({
+      eq: vi.fn(() => ({ maybeSingle: maybeSingleComment })),
+    }));
+    const from = vi.fn(() => ({ select: selectComment }));
+    const client: Client = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: USER_ID } },
+          error: null,
+        }),
+      },
+      from,
+    };
+    const route = await loadRoute(client);
+    const res = await route.POST(
+      new Request("http://localhost", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ commentId: COMMENT_ID, reaction: "like" }),
+      }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("faz upsert quando usuário participa da leitura coletiva", async () => {
+    const maybeSingleComment = vi.fn().mockResolvedValue({
+      data: { id: COMMENT_ID, book_id: BOOK_ID },
+      error: null,
+    });
+    const selectComment = vi.fn(() => ({
+      eq: vi.fn(() => ({ maybeSingle: maybeSingleComment })),
+    }));
+
+    const maybeSingleBook = vi.fn().mockResolvedValue({
+      data: {
+        user_id: null,
+        chosen_by: USER_ID,
+        readers: [USER_ID, "other-b"],
+      },
+      error: null,
+    });
+    const selectBook = vi.fn(() => ({
+      eq: vi.fn(() => ({ maybeSingle: maybeSingleBook })),
+    }));
+
+    const upsert = vi.fn().mockResolvedValue({ error: null });
+
+    const reactionsSelectEq = vi.fn().mockResolvedValue({
+      data: [{ user_id: USER_ID, reaction: "like" }],
+      error: null,
+    });
+    const reactionsSelect = vi.fn(() => ({
+      eq: reactionsSelectEq,
+    }));
+
+    const from = vi.fn((table: string) => {
+      if (table === "collective_reading_comments") return { select: selectComment };
+      if (table === "books") return { select: selectBook };
+      if (table === "collective_reading_comment_reactions") {
+        return {
+          upsert,
+          select: reactionsSelect,
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    });
+
+    const client: Client = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: USER_ID } },
+          error: null,
+        }),
+      },
+      from,
+    };
+
+    const route = await loadRoute(client);
+    const res = await route.POST(
+      new Request("http://localhost", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ commentId: COMMENT_ID, reaction: "like" }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      commentId: COMMENT_ID,
+      likeCount: 1,
+      dislikeCount: 0,
+      userReaction: "like",
+    });
+    expect(upsert).toHaveBeenCalledWith(
+      {
+        comment_id: COMMENT_ID,
+        book_id: BOOK_ID,
+        user_id: USER_ID,
+        reaction: "like",
+      },
+      { onConflict: "comment_id,user_id" },
+    );
+  });
+});

--- a/src/app/api/collective-reading-comment-reactions/route.ts
+++ b/src/app/api/collective-reading-comment-reactions/route.ts
@@ -1,0 +1,155 @@
+import { createClient } from "@/lib/supabase/server";
+import {
+  canUserParticipateInBook,
+  isCollectiveReadingBook,
+} from "@/lib/security/bookParticipation";
+import { requireUser } from "@/app/api/_utils/requireUser";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+const bodySchema = z.object({
+  commentId: z.string().uuid(),
+  reaction: z.enum(["like", "dislike"]).nullable(),
+});
+
+async function aggregateCommentReactionCounts(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  commentId: string,
+  viewerUserId: string,
+) {
+  const { data: rows, error } = await supabase
+    .from("collective_reading_comment_reactions")
+    .select("user_id, reaction")
+    .eq("comment_id", commentId);
+
+  if (error) {
+    return { error: error.message as string, payload: null as null };
+  }
+
+  let likeCount = 0;
+  let dislikeCount = 0;
+  let userReaction: "like" | "dislike" | null = null;
+
+  for (const r of rows ?? []) {
+    if (r.reaction === "like") likeCount += 1;
+    else if (r.reaction === "dislike") dislikeCount += 1;
+    if (r.user_id === viewerUserId) {
+      userReaction =
+        r.reaction === "like" || r.reaction === "dislike"
+          ? r.reaction
+          : null;
+    }
+  }
+
+  return {
+    error: null as null,
+    payload: {
+      commentId,
+      likeCount,
+      dislikeCount,
+      userReaction,
+    },
+  };
+}
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const auth = await requireUser(supabase);
+  if (auth.errorResponse) return auth.errorResponse;
+
+  let json: unknown;
+  try {
+    json = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid payload", details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const { commentId, reaction } = parsed.data;
+
+  const { data: comment, error: commentErr } = await supabase
+    .from("collective_reading_comments")
+    .select("id, book_id")
+    .eq("id", commentId)
+    .maybeSingle();
+
+  if (commentErr) {
+    return NextResponse.json({ error: commentErr.message }, { status: 500 });
+  }
+  if (!comment) {
+    return NextResponse.json({ error: "Comment not found" }, { status: 404 });
+  }
+
+  const { data: book, error: bookErr } = await supabase
+    .from("books")
+    .select("user_id,chosen_by,readers")
+    .eq("id", comment.book_id)
+    .maybeSingle();
+
+  if (bookErr) {
+    return NextResponse.json({ error: bookErr.message }, { status: 500 });
+  }
+  if (!book) {
+    return NextResponse.json({ error: "Book not found" }, { status: 404 });
+  }
+
+  const readers = book.readers as string[] | null;
+  if (!isCollectiveReadingBook(readers)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (
+    !canUserParticipateInBook(auth.user.id, {
+      user_id: book.user_id,
+      chosen_by: book.chosen_by,
+      readers,
+    })
+  ) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (reaction === null) {
+    const { error: delErr } = await supabase
+      .from("collective_reading_comment_reactions")
+      .delete()
+      .eq("comment_id", commentId)
+      .eq("user_id", auth.user.id);
+
+    if (delErr) {
+      return NextResponse.json({ error: delErr.message }, { status: 500 });
+    }
+  } else {
+    const { error: upsertErr } = await supabase
+      .from("collective_reading_comment_reactions")
+      .upsert(
+        {
+          comment_id: commentId,
+          book_id: comment.book_id,
+          user_id: auth.user.id,
+          reaction,
+        },
+        { onConflict: "comment_id,user_id" },
+      );
+
+    if (upsertErr) {
+      return NextResponse.json({ error: upsertErr.message }, { status: 500 });
+    }
+  }
+
+  const aggregated = await aggregateCommentReactionCounts(
+    supabase,
+    commentId,
+    auth.user.id,
+  );
+  if (aggregated.error) {
+    return NextResponse.json({ error: aggregated.error }, { status: 500 });
+  }
+  return NextResponse.json(aggregated.payload, { status: 200 });
+}

--- a/src/app/api/collective-reading-comments/[id]/route.test.ts
+++ b/src/app/api/collective-reading-comments/[id]/route.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+
+const COMMENT_ID = "550e8400-e29b-41d4-a716-446655440099";
+const USER_ID = "660e8400-e29b-41d4-a716-446655440002";
+
+type Client = {
+  auth: { getUser: ReturnType<typeof vi.fn> };
+  from: ReturnType<typeof vi.fn>;
+};
+
+async function loadRoute(client: Client) {
+  vi.resetModules();
+  vi.doMock("@/lib/supabase/server", () => ({
+    createClient: vi.fn().mockResolvedValue(client),
+  }));
+  return import("./route");
+}
+
+describe("DELETE /api/collective-reading-comments/[id]", () => {
+  it("retorna 403 quando o comentário é de outro usuário", async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: { id: COMMENT_ID, user_id: "other-user" },
+      error: null,
+    });
+    const select = vi.fn(() => ({
+      eq: vi.fn(() => ({ maybeSingle })),
+    }));
+    const from = vi.fn(() => ({ select }));
+    const client: Client = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: USER_ID } },
+          error: null,
+        }),
+      },
+      from,
+    };
+    const route = await loadRoute(client);
+    const res = await route.DELETE(
+      new Request("http://localhost"),
+      { params: Promise.resolve({ id: COMMENT_ID }) },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("remove quando user_id confere", async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: { id: COMMENT_ID, user_id: USER_ID },
+      error: null,
+    });
+    const select = vi.fn(() => ({
+      eq: vi.fn(() => ({ maybeSingle })),
+    }));
+    const deleteEq = vi.fn().mockResolvedValue({ error: null });
+    const deleteFn = vi.fn(() => ({ eq: deleteEq }));
+    let tableCall = 0;
+    const from = vi.fn(() => {
+      tableCall += 1;
+      if (tableCall === 1) return { select };
+      return { delete: deleteFn };
+    });
+    const client: Client = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: USER_ID } },
+          error: null,
+        }),
+      },
+      from,
+    };
+    const route = await loadRoute(client);
+    const res = await route.DELETE(
+      new Request("http://localhost"),
+      { params: Promise.resolve({ id: COMMENT_ID }) },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true });
+    expect(deleteEq).toHaveBeenCalledWith("id", COMMENT_ID);
+  });
+});

--- a/src/app/api/collective-reading-comments/[id]/route.ts
+++ b/src/app/api/collective-reading-comments/[id]/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+import { requireUser } from "@/app/api/_utils/requireUser";
+import { createClient } from "@/lib/supabase/server";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function DELETE(_request: Request, ctx: Ctx) {
+  const { id } = await ctx.params;
+  const supabase = await createClient();
+  const auth = await requireUser(supabase);
+  if (auth.errorResponse) return auth.errorResponse;
+
+  const { data: row, error: findErr } = await supabase
+    .from("collective_reading_comments")
+    .select("id, user_id")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (findErr) {
+    return NextResponse.json({ error: findErr.message }, { status: 500 });
+  }
+  if (!row) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  if (row.user_id !== auth.user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { error: delErr } = await supabase
+    .from("collective_reading_comments")
+    .delete()
+    .eq("id", id);
+
+  if (delErr) {
+    return NextResponse.json({ error: delErr.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true as const });
+}

--- a/src/app/api/collective-reading-comments/route.test.ts
+++ b/src/app/api/collective-reading-comments/route.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from "vitest";
+
+const BOOK_ID = "550e8400-e29b-41d4-a716-446655440001";
+const USER_ID = "660e8400-e29b-41d4-a716-446655440002";
+
+type Client = {
+  auth: { getUser: ReturnType<typeof vi.fn> };
+  from: ReturnType<typeof vi.fn>;
+};
+
+async function loadRoute(client: Client) {
+  vi.resetModules();
+  vi.doMock("@/lib/supabase/server", () => ({
+    createClient: vi.fn().mockResolvedValue(client),
+  }));
+  return import("./route");
+}
+
+describe("POST /api/collective-reading-comments", () => {
+  it("retorna 401 sem sessão", async () => {
+    const client: Client = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: null },
+          error: null,
+        }),
+      },
+      from: vi.fn(),
+    };
+    const route = await loadRoute(client);
+    const res = await route.POST(
+      new Request("http://localhost", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          bookId: BOOK_ID,
+          content: "Comentário",
+        }),
+      }),
+    );
+    expect(res.status).toBe(401);
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it("retorna 403 quando o livro não é leitura coletiva (apenas um leitor)", async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: {
+        user_id: null,
+        chosen_by: USER_ID,
+        readers: [USER_ID],
+      },
+      error: null,
+    });
+    const select = vi.fn(() => ({
+      eq: vi.fn(() => ({ maybeSingle })),
+    }));
+    const client: Client = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: USER_ID } },
+          error: null,
+        }),
+      },
+      from: vi.fn(() => ({ select })),
+    };
+    const route = await loadRoute(client);
+    const res = await route.POST(
+      new Request("http://localhost", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          bookId: BOOK_ID,
+          content: "Comentário",
+        }),
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("retorna 403 quando usuário não participa do livro coletivo", async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: {
+        user_id: null,
+        chosen_by: "other-a",
+        readers: ["other-a", "other-b"],
+      },
+      error: null,
+    });
+    const select = vi.fn(() => ({
+      eq: vi.fn(() => ({ maybeSingle })),
+    }));
+    const client: Client = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: USER_ID } },
+          error: null,
+        }),
+      },
+      from: vi.fn(() => ({ select })),
+    };
+    const route = await loadRoute(client);
+    const res = await route.POST(
+      new Request("http://localhost", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          bookId: BOOK_ID,
+          content: "Comentário",
+        }),
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("insere comentário quando há dois leitores e usuário participa", async () => {
+    const inserted = {
+      id: "c1",
+      book_id: BOOK_ID,
+      user_id: USER_ID,
+      content: "Comentário",
+      created_at: "2026-05-09T12:00:00Z",
+    };
+    const maybeSingleBook = vi.fn().mockResolvedValue({
+      data: {
+        user_id: null,
+        chosen_by: USER_ID,
+        readers: [USER_ID, "other-b"],
+      },
+      error: null,
+    });
+    const selectBook = vi.fn(() => ({
+      eq: vi.fn(() => ({ maybeSingle: maybeSingleBook })),
+    }));
+    const singleInsert = vi.fn().mockResolvedValue({
+      data: inserted,
+      error: null,
+    });
+    const insert = vi.fn(() => ({
+      select: vi.fn(() => ({ single: singleInsert })),
+    }));
+    let fromCall = 0;
+    const from = vi.fn((table: string) => {
+      fromCall += 1;
+      if (table === "books") return { select: selectBook };
+      if (table === "collective_reading_comments") return { insert };
+      throw new Error(`unexpected table ${table}`);
+    });
+    const client: Client = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: USER_ID } },
+          error: null,
+        }),
+      },
+      from,
+    };
+    const route = await loadRoute(client);
+    const res = await route.POST(
+      new Request("http://localhost", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          bookId: BOOK_ID,
+          content: "Comentário",
+        }),
+      }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body).toEqual(inserted);
+    expect(insert).toHaveBeenCalledWith({
+      book_id: BOOK_ID,
+      user_id: USER_ID,
+      content: "Comentário",
+    });
+  });
+});

--- a/src/app/api/collective-reading-comments/route.ts
+++ b/src/app/api/collective-reading-comments/route.ts
@@ -1,0 +1,78 @@
+import { createClient } from "@/lib/supabase/server";
+import {
+  canUserParticipateInBook,
+  isCollectiveReadingBook,
+} from "@/lib/security/bookParticipation";
+import { requireUser } from "@/app/api/_utils/requireUser";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+const bodySchema = z.object({
+  bookId: z.string().uuid(),
+  content: z.string().min(1),
+});
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const auth = await requireUser(supabase);
+  if (auth.errorResponse) return auth.errorResponse;
+
+  let json: unknown;
+  try {
+    json = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid payload", details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const { data: book, error: bookErr } = await supabase
+    .from("books")
+    .select("user_id,chosen_by,readers")
+    .eq("id", parsed.data.bookId)
+    .maybeSingle();
+
+  if (bookErr) {
+    return NextResponse.json({ error: bookErr.message }, { status: 500 });
+  }
+  if (!book) {
+    return NextResponse.json({ error: "Book not found" }, { status: 404 });
+  }
+
+  const readers = book.readers as string[] | null;
+  if (!isCollectiveReadingBook(readers)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (
+    !canUserParticipateInBook(auth.user.id, {
+      user_id: book.user_id,
+      chosen_by: book.chosen_by,
+      readers,
+    })
+  ) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { data, error } = await supabase
+    .from("collective_reading_comments")
+    .insert({
+      book_id: parsed.data.bookId,
+      user_id: auth.user.id,
+      content: parsed.data.content.trim(),
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json(data, { status: 201 });
+}

--- a/src/components/bookCard/bookCard.tsx
+++ b/src/components/bookCard/bookCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { BookOpen, EllipsisVerticalIcon, Heart, Lock, Users } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
@@ -39,6 +40,8 @@ export function BookCard(props: BookCardProps) {
     showFavoriteToggle,
     handleFavoriteClick,
     isFavoritePending,
+    canAccessCollectiveReading,
+    collectiveReadingHref,
   } = useBookCard(props);
 
   const showTopActions =
@@ -225,6 +228,18 @@ export function BookCard(props: BookCardProps) {
               </span>
             )}
           </div>
+        )}
+
+        {canAccessCollectiveReading && (
+          <Link
+            href={collectiveReadingHref}
+            className={cn(
+              "w-fit text-xs font-medium text-violet-600 underline-offset-2 hover:underline dark:text-violet-400 cursor-pointer",
+              isShelf ? "mt-0.5" : "mt-1",
+            )}
+          >
+            Leitura coletiva
+          </Link>
         )}
 
         {isOwnSoloBook && (

--- a/src/components/bookCard/hooks/useBookCard.ts
+++ b/src/components/bookCard/hooks/useBookCard.ts
@@ -4,8 +4,9 @@ import { useRouter } from "next/navigation";
 import { useIsLoggedIn } from "@/stores/hooks/useAuth";
 import { useCallback, useMemo } from "react";
 import type { MouseEvent } from "react";
-import { BookService } from "@/services/books/books.service";
+import { canUserParticipateInBook } from "@/lib/security/bookParticipation";
 import { BookshelfServiceBooks } from "@/modules/bookshelves/services/bookshelvesBooks.service";
+import { BookService } from "@/services/books/books.service";
 import { BookMapper } from "@/services/books/books.mapper";
 import { useUserStore } from "@/stores/userStore";
 import { useToggleBookFavorite } from "@/services/bookFavorites/hooks/useToggleBookFavorite";
@@ -32,6 +33,22 @@ export function useBookCard({
   const isOwnSoloBook = useMemo(
     () => isSoloBook && !!currentUser?.id && book.chosen_by === currentUser.id,
     [isSoloBook, currentUser?.id, book.chosen_by],
+  );
+
+  const canAccessCollectiveReading = useMemo(() => {
+    if (!isLogged || !BookMapper.isCollectiveReadingBook(book)) return false;
+    if (!currentUser?.id) return false;
+    return canUserParticipateInBook(currentUser.id, {
+      user_id: book.user_id,
+      chosen_by: book.chosen_by,
+      readers: book.readerIds,
+    });
+  }, [book, currentUser?.id, isLogged]);
+
+  const collectiveReadingHref = useMemo(
+    () =>
+      `/collective-reading/${book.id}/${encodeURIComponent(book.title)}`,
+    [book.id, book.title],
   );
 
   const shareOnWhatsApp = useCallback(() => {
@@ -204,5 +221,7 @@ export function useBookCard({
     showFavoriteToggle,
     handleFavoriteClick,
     isFavoritePending,
+    canAccessCollectiveReading,
+    collectiveReadingHref,
   };
 }

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -14,7 +14,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer border-zinc-400 bg-background dark:border-zinc-500 dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/src/lib/security/bookParticipation.test.ts
+++ b/src/lib/security/bookParticipation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { canUserParticipateInBook } from "./bookParticipation";
+import {
+  canUserParticipateInBook,
+  isCollectiveReadingBook,
+} from "./bookParticipation";
 
 const uid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 const other = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
@@ -87,5 +90,18 @@ describe("canUserParticipateInBook (RN42)", () => {
         readers: [uid],
       }),
     ).toBe(true);
+  });
+});
+
+describe("isCollectiveReadingBook (RN59)", () => {
+  it("retorna true com mais de um reader", () => {
+    expect(isCollectiveReadingBook(["a", "b"])).toBe(true);
+  });
+
+  it("retorna false com zero ou um reader", () => {
+    expect(isCollectiveReadingBook([])).toBe(false);
+    expect(isCollectiveReadingBook(["a"])).toBe(false);
+    expect(isCollectiveReadingBook(undefined)).toBe(false);
+    expect(isCollectiveReadingBook(null)).toBe(false);
   });
 });

--- a/src/lib/security/bookParticipation.ts
+++ b/src/lib/security/bookParticipation.ts
@@ -1,5 +1,6 @@
 /**
- * Alinhado a Second Brain business-rules RN42 / RN43: participação em livro (leitura coletiva).
+ * Alinhado a Second Brain business-rules RN42 / RN43 / RN59: participação em livro
+ * (leitura coletiva e comentários) e critério de livro coletivo (mais de um reader).
  * Usado nas rotas API (camada app) em conjunto com RLS no banco.
  */
 export type BookParticipationRow = {
@@ -17,4 +18,10 @@ export function canUserParticipateInBook(
   if (row.chosen_by && row.chosen_by === userId) return true;
   const readers = row.readers ?? [];
   return readers.includes(userId);
+}
+
+export function isCollectiveReadingBook(
+  readers: string[] | null | undefined,
+): boolean {
+  return (readers?.length ?? 0) > 1;
 }

--- a/src/modules/collectiveReading/components/CollectiveReadingCommentList.tsx
+++ b/src/modules/collectiveReading/components/CollectiveReadingCommentList.tsx
@@ -1,0 +1,117 @@
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ThumbsDown, ThumbsUp, Trash2 } from "lucide-react";
+
+import type { CollectiveReadingCommentListProps } from "../types/collectiveReading.types";
+
+export default function CollectiveReadingCommentList({
+  comments,
+  isLoading,
+  currentUserId,
+  reactionPendingCommentId,
+  onRequestDelete,
+  onToggleReaction,
+}: CollectiveReadingCommentListProps) {
+  if (isLoading) {
+    return (
+      <div className="space-y-3" aria-busy="true">
+        <Skeleton className="h-24 w-full rounded-xl" />
+        <Skeleton className="h-24 w-full rounded-xl" />
+      </div>
+    );
+  }
+
+  if (!comments.length) {
+    return (
+      <p className="text-sm text-zinc-600 dark:text-zinc-400">
+        Nenhum comentário ainda. Seja o primeiro a comentar esta leitura.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-3" role="list">
+      {comments.map((c) => (
+        <li key={c.id}>
+          <Card className="border-zinc-200 bg-zinc-50/50 shadow-sm dark:border-zinc-800 dark:bg-zinc-900/40">
+            <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0 pb-2">
+              <div className="min-w-0 flex-1 space-y-1">
+                <CardTitle className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
+                  {c.authorDisplayName}
+                </CardTitle>
+                <CardDescription className="text-xs">
+                  {new Date(c.createdAt).toLocaleString("pt-BR", {
+                    dateStyle: "short",
+                    timeStyle: "short",
+                  })}
+                </CardDescription>
+              </div>
+              {currentUserId && c.userId === currentUserId ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="size-9 shrink-0 text-zinc-500 hover:bg-rose-50 hover:text-rose-600 dark:text-zinc-400 dark:hover:bg-rose-950/50 dark:hover:text-rose-400 cursor-pointer"
+                  aria-label="Remover comentário"
+                  onClick={() => onRequestDelete(c.id)}
+                >
+                  <Trash2 className="size-4" aria-hidden />
+                </Button>
+              ) : null}
+            </CardHeader>
+            <CardContent className="space-y-3 pt-0">
+              <p className="whitespace-pre-wrap text-sm text-zinc-700 dark:text-zinc-300">
+                {c.content}
+              </p>
+              {currentUserId ? (
+                <div className="flex flex-wrap items-center gap-2 border-t border-zinc-200/80 pt-3 dark:border-zinc-800/80">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    disabled={Boolean(reactionPendingCommentId)}
+                    className={`h-8 gap-1.5 rounded-lg px-2 text-xs cursor-pointer ${
+                      c.userReaction === "like"
+                        ? "bg-emerald-100 text-emerald-800 hover:bg-emerald-100 dark:bg-emerald-950/60 dark:text-emerald-200 dark:hover:bg-emerald-950/60"
+                        : "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800/80"
+                    }`}
+                    aria-pressed={c.userReaction === "like"}
+                    aria-label={`Curtir comentário. ${c.likeCount} curtida(s).`}
+                    onClick={() => onToggleReaction(c.id, "like")}
+                  >
+                    <ThumbsUp className="size-3.5 shrink-0" aria-hidden />
+                    <span>{c.likeCount}</span>
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    disabled={Boolean(reactionPendingCommentId)}
+                    className={`h-8 gap-1.5 rounded-lg px-2 text-xs cursor-pointer ${
+                      c.userReaction === "dislike"
+                        ? "bg-amber-100 text-amber-900 hover:bg-amber-100 dark:bg-amber-950/50 dark:text-amber-100 dark:hover:bg-amber-950/50"
+                        : "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800/80"
+                    }`}
+                    aria-pressed={c.userReaction === "dislike"}
+                    aria-label={`Não curtir comentário. ${c.dislikeCount} não curtida(s).`}
+                    onClick={() => onToggleReaction(c.id, "dislike")}
+                  >
+                    <ThumbsDown className="size-3.5 shrink-0" aria-hidden />
+                    <span>{c.dislikeCount}</span>
+                  </Button>
+                </div>
+              ) : null}
+            </CardContent>
+          </Card>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/modules/collectiveReading/hooks/useCollectiveReadingCommentsRealtime.ts
+++ b/src/modules/collectiveReading/hooks/useCollectiveReadingCommentsRealtime.ts
@@ -1,0 +1,192 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+
+import { createClient } from "@/lib/supabase/client";
+
+import {
+  CollectiveReadingCommentMapper,
+  type CollectiveReadingCommentRow,
+} from "../services/mappers/collectiveReadingComment.mapper";
+import type { CollectiveReadingCommentDomain } from "../types/collectiveReading.types";
+import { getCollectiveReadingCommentsQueryKey } from "../utils/collectiveReadingCommentQueryKey";
+
+async function refreshCommentReactionStats(
+  supabase: ReturnType<typeof createClient>,
+  queryClient: QueryClient,
+  queryKey: ReturnType<typeof getCollectiveReadingCommentsQueryKey>,
+  commentId: string,
+  viewerUserId: string | undefined,
+) {
+  const { data, error } = await supabase
+    .from("collective_reading_comment_reactions")
+    .select("user_id, reaction")
+    .eq("comment_id", commentId);
+
+  if (error || !data) return;
+
+  let likeCount = 0;
+  let dislikeCount = 0;
+  let userReaction: CollectiveReadingCommentDomain["userReaction"] = null;
+
+  for (const r of data) {
+    if (r.reaction === "like") likeCount += 1;
+    else if (r.reaction === "dislike") dislikeCount += 1;
+    if (viewerUserId && r.user_id === viewerUserId) {
+      userReaction =
+        r.reaction === "like" || r.reaction === "dislike"
+          ? r.reaction
+          : null;
+    }
+  }
+
+  queryClient.setQueryData<CollectiveReadingCommentDomain[]>(
+    queryKey,
+    (old) => {
+      if (!old) return old;
+      return old.map((c) =>
+        c.id === commentId
+          ? { ...c, likeCount, dislikeCount, userReaction }
+          : c,
+      );
+    },
+  );
+}
+
+export function useCollectiveReadingCommentsRealtime(
+  bookId: string,
+  enabled: boolean,
+  viewerUserId: string | undefined,
+) {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!enabled || !bookId) return;
+
+    const supabase = createClient();
+    const queryKey = getCollectiveReadingCommentsQueryKey(bookId);
+
+    const mergeComment = (domain: CollectiveReadingCommentDomain) => {
+      queryClient.setQueryData<CollectiveReadingCommentDomain[]>(
+        queryKey,
+        (old) => {
+          const list = old ?? [];
+          if (list.some((c) => c.id === domain.id)) return list;
+          return [domain, ...list];
+        },
+      );
+    };
+
+    const removeCommentById = (commentId: string) => {
+      queryClient.setQueryData<CollectiveReadingCommentDomain[]>(
+        queryKey,
+        (old) => (old ?? []).filter((c) => c.id !== commentId),
+      );
+    };
+
+    const channel = supabase
+      .channel(`collective-reading-comments:${bookId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "collective_reading_comments",
+          filter: `book_id=eq.${bookId}`,
+        },
+        async (payload) => {
+          const row = payload.new as CollectiveReadingCommentRow | null;
+          if (!row?.id) return;
+          const { data: userRow } = await supabase
+            .from("users")
+            .select("display_name")
+            .eq("id", row.user_id)
+            .maybeSingle();
+          const domain = CollectiveReadingCommentMapper.toDomain(
+            row,
+            userRow?.display_name ?? "Leitor",
+          );
+          mergeComment(domain);
+        },
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "DELETE",
+          schema: "public",
+          table: "collective_reading_comments",
+          filter: `book_id=eq.${bookId}`,
+        },
+        (payload) => {
+          const oldRow = payload.old as { id?: string } | null;
+          if (!oldRow?.id) return;
+          removeCommentById(oldRow.id);
+        },
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "collective_reading_comment_reactions",
+          filter: `book_id=eq.${bookId}`,
+        },
+        async (payload) => {
+          const row = payload.new as { comment_id?: string } | null;
+          if (!row?.comment_id) return;
+          await refreshCommentReactionStats(
+            supabase,
+            queryClient,
+            queryKey,
+            row.comment_id,
+            viewerUserId,
+          );
+        },
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "collective_reading_comment_reactions",
+          filter: `book_id=eq.${bookId}`,
+        },
+        async (payload) => {
+          const row = payload.new as { comment_id?: string } | null;
+          if (!row?.comment_id) return;
+          await refreshCommentReactionStats(
+            supabase,
+            queryClient,
+            queryKey,
+            row.comment_id,
+            viewerUserId,
+          );
+        },
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "DELETE",
+          schema: "public",
+          table: "collective_reading_comment_reactions",
+          filter: `book_id=eq.${bookId}`,
+        },
+        async (payload) => {
+          const row = payload.old as { comment_id?: string } | null;
+          if (!row?.comment_id) return;
+          await refreshCommentReactionStats(
+            supabase,
+            queryClient,
+            queryKey,
+            row.comment_id,
+            viewerUserId,
+          );
+        },
+      )
+      .subscribe();
+
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  }, [bookId, enabled, queryClient, viewerUserId]);
+}

--- a/src/modules/collectiveReading/hooks/useCollectiveReadingScreen.ts
+++ b/src/modules/collectiveReading/hooks/useCollectiveReadingScreen.ts
@@ -1,0 +1,210 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
+
+import { useSchedule } from "@/modules/schedule/hooks/useSchedule";
+import { useUserStore } from "@/stores/userStore";
+
+import { CollectiveReadingCommentsService } from "../services/collectiveReadingComments.service";
+import type { CollectiveReadingCommentDomain } from "../types/collectiveReading.types";
+import {
+  getCollectiveReadingCommentsQueryKey,
+  getCollectiveReadingGateQueryKey,
+} from "../utils/collectiveReadingCommentQueryKey";
+import { getCurrentScheduleChapterInfo } from "../utils/currentScheduleChapter";
+import { useCollectiveReadingCommentsRealtime } from "./useCollectiveReadingCommentsRealtime";
+
+export function useCollectiveReadingScreen(bookId: string) {
+  const { user } = useUserStore();
+  const userId = user?.id;
+  const queryClient = useQueryClient();
+  const [draft, setDraft] = useState("");
+  const [deleteCommentId, setDeleteCommentId] = useState<string | null>(null);
+  const [deleteCommentOpen, setDeleteCommentOpen] = useState(false);
+
+  const service = useMemo(() => new CollectiveReadingCommentsService(), []);
+
+  const {
+    schedule,
+    isLoadingSchedule,
+  } = useSchedule({ id: bookId });
+
+  const gateQuery = useQuery({
+    queryKey: getCollectiveReadingGateQueryKey(bookId, userId ?? ""),
+    queryFn: () => service.checkAccess(bookId, userId!),
+    enabled: Boolean(userId && bookId),
+  });
+
+  const gateCanAccess = Boolean(gateQuery.data?.canAccess);
+
+  useCollectiveReadingCommentsRealtime(
+    bookId,
+    Boolean(userId && bookId && gateCanAccess),
+    userId,
+  );
+
+  const commentsQuery = useQuery({
+    queryKey: getCollectiveReadingCommentsQueryKey(bookId),
+    queryFn: () => service.listByBookId(bookId, userId),
+    enabled: Boolean(userId && bookId && gateQuery.data?.canAccess),
+  });
+
+  const scheduleChapter = useMemo(
+    () => getCurrentScheduleChapterInfo(schedule),
+    [schedule],
+  );
+
+  const addComment = useMutation({
+    mutationFn: (content: string) => service.createComment(bookId, content),
+    onSuccess: (data) => {
+      queryClient.setQueryData<CollectiveReadingCommentDomain[]>(
+        getCollectiveReadingCommentsQueryKey(bookId),
+        (old) => {
+          const list = old ?? [];
+          if (list.some((c) => c.id === data.id)) return list;
+          return [data, ...list];
+        },
+      );
+      setDraft("");
+    },
+  });
+
+  const handleSubmitComment = useCallback(() => {
+    const trimmed = draft.trim();
+    if (!trimmed || addComment.isPending) return;
+    addComment.mutate(trimmed);
+  }, [addComment, draft]);
+
+  const deleteComment = useMutation({
+    mutationFn: (commentId: string) => service.removeComment(commentId),
+    onSuccess: (_, commentId) => {
+      queryClient.setQueryData<CollectiveReadingCommentDomain[]>(
+        getCollectiveReadingCommentsQueryKey(bookId),
+        (old) => (old ?? []).filter((c) => c.id !== commentId),
+      );
+      setDeleteCommentOpen(false);
+      setDeleteCommentId(null);
+    },
+  });
+
+  const handleOpenDeleteComment = useCallback((commentId: string) => {
+    setDeleteCommentId(commentId);
+    setDeleteCommentOpen(true);
+  }, []);
+
+  const handleDeleteCommentOpenChange = useCallback((open: boolean) => {
+    setDeleteCommentOpen(open);
+    if (!open) setDeleteCommentId(null);
+  }, []);
+
+  const handleDraftChange = useCallback((value: string) => {
+    setDraft(value);
+  }, []);
+
+  const {
+    mutate: mutateCommentReaction,
+    isPending: isCommentReactionPending,
+    variables: commentReactionVariables,
+  } = useMutation({
+    mutationFn: async ({
+      commentId,
+      value,
+    }: {
+      commentId: string;
+      value: "like" | "dislike";
+    }) => {
+      const list =
+        queryClient.getQueryData<CollectiveReadingCommentDomain[]>(
+          getCollectiveReadingCommentsQueryKey(bookId),
+        ) ?? [];
+      const c = list.find((x) => x.id === commentId);
+      const next = c?.userReaction === value ? null : value;
+      return service.setCommentReaction(commentId, next);
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData<CollectiveReadingCommentDomain[]>(
+        getCollectiveReadingCommentsQueryKey(bookId),
+        (old) =>
+          (old ?? []).map((c) =>
+            c.id === data.commentId
+              ? {
+                  ...c,
+                  likeCount: data.likeCount,
+                  dislikeCount: data.dislikeCount,
+                  userReaction: data.userReaction,
+                }
+              : c,
+          ),
+      );
+    },
+  });
+
+  const handleToggleReaction = useCallback(
+    (commentId: string, value: "like" | "dislike") => {
+      if (!userId || isCommentReactionPending) return;
+      mutateCommentReaction({ commentId, value });
+    },
+    [isCommentReactionPending, mutateCommentReaction, userId],
+  );
+
+  const confirmDeleteComment = useCallback(
+    (commentId: string) => deleteComment.mutateAsync(commentId),
+    [deleteComment],
+  );
+
+  const reactionPendingCommentId = isCommentReactionPending
+    ? commentReactionVariables?.commentId ?? null
+    : null;
+
+  return useMemo(
+    () => ({
+      userId,
+      gate: gateQuery.data,
+      gateLoading: gateQuery.isLoading,
+      gateError: gateQuery.isError,
+      comments: commentsQuery.data ?? [],
+      commentsLoading: commentsQuery.isLoading,
+      commentsError: commentsQuery.isError,
+      scheduleLoading: isLoadingSchedule,
+      scheduleChapter,
+      draft,
+      handleDraftChange,
+      handleSubmitComment,
+      isSubmittingComment: addComment.isPending,
+      deleteCommentId,
+      deleteCommentOpen,
+      handleDeleteCommentOpenChange,
+      handleOpenDeleteComment,
+      confirmDeleteComment,
+      deleteCommentPending: deleteComment.isPending,
+      handleToggleReaction,
+      reactionPendingCommentId,
+    }),
+    [
+      userId,
+      gateQuery.data,
+      gateQuery.isLoading,
+      gateQuery.isError,
+      commentsQuery.data,
+      commentsQuery.isLoading,
+      commentsQuery.isError,
+      isLoadingSchedule,
+      scheduleChapter,
+      draft,
+      handleDraftChange,
+      handleSubmitComment,
+      addComment.isPending,
+      deleteCommentId,
+      deleteCommentOpen,
+      handleDeleteCommentOpenChange,
+      handleOpenDeleteComment,
+      confirmDeleteComment,
+      deleteComment.isPending,
+      handleToggleReaction,
+      reactionPendingCommentId,
+    ],
+  );
+}

--- a/src/modules/collectiveReading/index.tsx
+++ b/src/modules/collectiveReading/index.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import Link from "next/link";
+import { CalendarDays, MessageCircle, Users } from "lucide-react";
+
+import { ConfirmDialog } from "@/components/confirmDialog";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import { useIsLoggedIn } from "@/stores/hooks/useAuth";
+
+import CollectiveReadingCommentList from "./components/CollectiveReadingCommentList";
+import { useCollectiveReadingScreen } from "./hooks/useCollectiveReadingScreen";
+import type { ClientCollectiveReadingProps } from "./types/collectiveReading.types";
+
+export default function ClientCollectiveReading({
+  id,
+  title,
+}: ClientCollectiveReadingProps) {
+  const isLogged = useIsLoggedIn();
+
+  const {
+    gate,
+    gateLoading,
+    gateError,
+    userId,
+    comments,
+    commentsLoading,
+    commentsError,
+    scheduleLoading,
+    scheduleChapter,
+    draft,
+    handleDraftChange,
+    handleSubmitComment,
+    isSubmittingComment,
+    deleteCommentId,
+    deleteCommentOpen,
+    handleDeleteCommentOpenChange,
+    handleOpenDeleteComment,
+    confirmDeleteComment,
+    deleteCommentPending,
+    handleToggleReaction,
+    reactionPendingCommentId,
+  } = useCollectiveReadingScreen(id);
+
+  if (!isLogged) {
+    return (
+      <div className="mx-auto w-full max-w-3xl space-y-6 px-4 py-7">
+        <header className="space-y-2">
+          <h1 className="page-title text-zinc-900 dark:text-zinc-100">
+            Leitura coletiva
+          </h1>
+          <p className="text-base text-zinc-600 dark:text-zinc-400">
+            Entre na sua conta para ver o espaço de conversa e comentários deste
+            livro.
+          </p>
+          <Button
+            asChild
+            className="mt-2 rounded-xl cursor-pointer"
+          >
+            <Link href="/auth">Entrar</Link>
+          </Button>
+        </header>
+      </div>
+    );
+  }
+
+  if (gateLoading) {
+    return (
+      <div className="mx-auto w-full max-w-3xl space-y-8 px-4 py-7">
+        <Skeleton className="mx-auto h-9 w-64 rounded-lg sm:mx-0" />
+        <Skeleton className="h-32 w-full rounded-2xl" />
+        <Skeleton className="h-40 w-full rounded-2xl" />
+      </div>
+    );
+  }
+
+  if (gateError || !gate) {
+    return (
+      <div className="mx-auto w-full max-w-3xl px-4 py-7">
+        <p className="text-red-600 dark:text-red-400">
+          Não foi possível carregar esta leitura coletiva. Tente novamente.
+        </p>
+      </div>
+    );
+  }
+
+  if (!gate.canAccess) {
+    return (
+      <div className="mx-auto w-full max-w-3xl space-y-4 px-4 py-7">
+        <h1 className="page-title text-zinc-900 dark:text-zinc-100">
+          Leitura coletiva
+        </h1>
+        <p className="text-zinc-600 dark:text-zinc-400">
+          Você não tem acesso a este espaço ou este livro não é uma leitura
+          coletiva (é necessário haver mais de um leitor no livro).
+        </p>
+        <Button asChild variant="outline" className="rounded-xl cursor-pointer">
+          <Link href="/">Voltar à home</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  const headline = gate.bookTitle || title;
+  const participantsLabel =
+    typeof gate.participantsDisplay === "string"
+      ? gate.participantsDisplay.trim()
+      : "";
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-8 px-4 py-7">
+      <header className="space-y-2">
+        <div className="flex flex-col items-center gap-3 sm:flex-row sm:items-start sm:gap-4">
+          <div className="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900/80">
+            <Users
+              className="size-6 text-violet-600 dark:text-violet-400"
+              aria-hidden
+            />
+          </div>
+          <div className="min-w-0 flex-1 space-y-2 text-center sm:text-left">
+            <h1 className="page-title text-zinc-900 dark:text-zinc-100">
+              Leitura coletiva — {headline}
+            </h1>
+            <p className="max-w-xl text-base text-zinc-600 dark:text-zinc-400">
+              Acompanhe onde você está no cronograma e troque ideias com quem
+              está lendo o mesmo livro.
+            </p>
+            {participantsLabel ? (
+              <p
+                className="inline-flex max-w-full flex-wrap items-center gap-1.5 rounded-xl border border-violet-200/80 bg-violet-50/80 px-3 py-2 text-left text-sm text-zinc-700 dark:border-violet-900/50 dark:bg-violet-950/30 dark:text-zinc-300"
+                aria-label={`Participantes da leitura: ${participantsLabel}`}
+              >
+                <Users
+                  className="size-4 shrink-0 text-violet-600 dark:text-violet-400"
+                  aria-hidden
+                />
+                <span className="min-w-0 leading-snug">
+                  <span className="font-semibold text-zinc-900 dark:text-zinc-100">
+                    Participando:{" "}
+                  </span>
+                  {participantsLabel}
+                </span>
+              </p>
+            ) : null}
+          </div>
+        </div>
+      </header>
+
+      <Card className="gap-0 overflow-hidden rounded-2xl border-zinc-200 py-0 shadow-sm dark:border-zinc-800 dark:bg-zinc-900/50">
+        <CardHeader className="border-b border-zinc-200 bg-zinc-50/80 px-5 py-4 dark:border-zinc-800 dark:bg-zinc-900/80 sm:px-6">
+          <CardTitle className="flex items-center gap-2 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+            <CalendarDays className="size-5 shrink-0 text-zinc-400" aria-hidden />
+            Seu próximo passo no cronograma
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="px-5 py-5 sm:px-6">
+          {scheduleLoading ? (
+            <Skeleton className="h-16 w-full rounded-xl" />
+          ) : scheduleChapter?.kind === "active" ? (
+            <p className="text-sm leading-relaxed text-zinc-700 dark:text-zinc-300">
+              No seu cronograma ativo, o foco atual é o dia{" "}
+              <strong className="font-semibold text-zinc-900 dark:text-zinc-100">
+                {scheduleChapter.dateLabel}
+              </strong>
+              : capítulos{" "}
+              <strong className="font-semibold text-zinc-900 dark:text-zinc-100">
+                {scheduleChapter.chaptersLabel}
+              </strong>
+              .
+            </p>
+          ) : scheduleChapter?.kind === "completed" ? (
+            <p className="text-sm leading-relaxed text-zinc-700 dark:text-zinc-300">
+              Seu cronograma está completo. Último dia registrado:{" "}
+              <strong className="font-semibold text-zinc-900 dark:text-zinc-100">
+                {scheduleChapter.lastDateLabel}
+              </strong>{" "}
+              (capítulos{" "}
+              <strong className="font-semibold text-zinc-900 dark:text-zinc-100">
+                {scheduleChapter.lastChaptersLabel}
+              </strong>
+              ).
+            </p>
+          ) : (
+            <p className="text-sm leading-relaxed text-zinc-700 dark:text-zinc-300">
+              Não há cronograma ativo para você neste livro.{" "}
+              <Link
+                href={`/schedule/${id}/${encodeURIComponent(headline)}`}
+                className="font-medium text-violet-600 underline-offset-2 hover:underline dark:text-violet-400"
+              >
+                Criar ou ver cronograma
+              </Link>
+              .
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <section
+        className="space-y-4"
+        aria-labelledby="collective-comments-heading"
+      >
+        <div className="flex items-center gap-2">
+          <MessageCircle
+            className="size-5 text-violet-500"
+            aria-hidden
+          />
+          <h2
+            id="collective-comments-heading"
+            className="text-lg font-semibold text-zinc-900 dark:text-zinc-100"
+          >
+            Comentários
+          </h2>
+        </div>
+
+        <div className="space-y-3">
+          <Textarea
+            value={draft}
+            onChange={(e) => handleDraftChange(e.target.value)}
+            placeholder="Escreva um comentário sobre a leitura…"
+            className="min-h-[100px] rounded-xl border-zinc-200 dark:border-zinc-800"
+            disabled={isSubmittingComment}
+          />
+          <Button
+            type="button"
+            onClick={handleSubmitComment}
+            disabled={isSubmittingComment || !draft.trim()}
+            className="rounded-xl cursor-pointer"
+          >
+            {isSubmittingComment ? "Enviando…" : "Publicar comentário"}
+          </Button>
+        </div>
+
+        {commentsError ? (
+          <p className="text-sm text-red-600 dark:text-red-400">
+            Não foi possível carregar os comentários.
+          </p>
+        ) : (
+          <CollectiveReadingCommentList
+            comments={comments}
+            isLoading={commentsLoading}
+            currentUserId={userId}
+            reactionPendingCommentId={reactionPendingCommentId}
+            onRequestDelete={handleOpenDeleteComment}
+            onToggleReaction={handleToggleReaction}
+          />
+        )}
+        {deleteCommentId ? (
+          <ConfirmDialog
+            title="Remover comentário"
+            description="Deseja remover este comentário? Essa ação não pode ser desfeita."
+            id={deleteCommentId}
+            queryKeyToInvalidate="collective-reading-comments"
+            onConfirm={confirmDeleteComment}
+            open={deleteCommentOpen}
+            onOpenChange={handleDeleteCommentOpenChange}
+            buttonLabel={deleteCommentPending ? "Removendo…" : "Remover"}
+          />
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/src/modules/collectiveReading/services/collectiveReadingComments.service.ts
+++ b/src/modules/collectiveReading/services/collectiveReadingComments.service.ts
@@ -1,0 +1,301 @@
+import { createClient } from "@/lib/supabase/client";
+import {
+  canUserParticipateInBook,
+  isCollectiveReadingBook,
+} from "@/lib/security/bookParticipation";
+import { apiJson } from "@/lib/api/clientJsonFetch";
+import { ErrorHandler, RepositoryError } from "@/services/errors/error";
+import { formatReaderIds } from "@/utils/formatters";
+
+import {
+  CollectiveReadingCommentMapper,
+  type CollectiveReadingCommentReactionStats,
+  type CollectiveReadingCommentRow,
+} from "./mappers/collectiveReadingComment.mapper";
+import type {
+  CollectiveReadingCommentDomain,
+  CollectiveReadingCommentUserReaction,
+  CollectiveReadingGateResult,
+} from "../types/collectiveReading.types";
+
+export type CollectiveReadingCommentReactionResult = {
+  commentId: string;
+  likeCount: number;
+  dislikeCount: number;
+  userReaction: CollectiveReadingCommentUserReaction;
+};
+
+export class CollectiveReadingCommentsService {
+  private supabase = createClient();
+
+  private buildReactionStatsByCommentId(
+    reactionRows: {
+      comment_id: string;
+      user_id: string;
+      reaction: string;
+    }[],
+    viewerUserId: string | undefined,
+  ): Map<string, CollectiveReadingCommentReactionStats> {
+    const aggregated = new Map<string, CollectiveReadingCommentReactionStats>();
+
+    for (const r of reactionRows) {
+      let cur = aggregated.get(r.comment_id);
+      if (!cur) {
+        cur = {
+          likeCount: 0,
+          dislikeCount: 0,
+          userReaction: null,
+        };
+        aggregated.set(r.comment_id, cur);
+      }
+      if (r.reaction === "like") cur.likeCount += 1;
+      else if (r.reaction === "dislike") cur.dislikeCount += 1;
+      if (viewerUserId && r.user_id === viewerUserId) {
+        cur.userReaction =
+          r.reaction === "like" || r.reaction === "dislike"
+            ? r.reaction
+            : null;
+      }
+    }
+
+    return aggregated;
+  }
+
+  async checkAccess(
+    bookId: string,
+    userId: string,
+  ): Promise<CollectiveReadingGateResult> {
+    try {
+      const { data, error } = await this.supabase
+        .from("books")
+        .select("title,readers,chosen_by,user_id")
+        .eq("id", bookId)
+        .maybeSingle();
+
+      if (error) {
+        throw new RepositoryError(
+          "Falha ao validar leitura coletiva",
+          undefined,
+          undefined,
+          error,
+          { bookId },
+        );
+      }
+      if (!data) {
+        return {
+          canAccess: false,
+          bookTitle: "",
+          participantsDisplay: "",
+        };
+      }
+      const readers = data.readers as string[] | null;
+      const ok =
+        isCollectiveReadingBook(readers) &&
+        canUserParticipateInBook(userId, {
+          user_id: data.user_id,
+          chosen_by: data.chosen_by,
+          readers,
+        });
+      const readerIds = [...new Set(readers ?? [])];
+      let participantsDisplay = "";
+      if (readerIds.length > 0) {
+        const { data: userRows, error: usersErr } = await this.supabase
+          .from("users")
+          .select("id, display_name")
+          .in("id", readerIds);
+        if (usersErr) {
+          ErrorHandler.log(
+            ErrorHandler.normalize(usersErr, {
+              service: "CollectiveReadingCommentsService",
+              method: "checkAccess.usersLookup",
+              bookId,
+            }),
+          );
+        }
+        participantsDisplay =
+          formatReaderIds(readers, userRows ?? []) ?? "";
+      }
+      return {
+        canAccess: ok,
+        bookTitle: data.title ?? "",
+        participantsDisplay,
+      };
+    } catch (error) {
+      const normalizedError = ErrorHandler.normalize(error, {
+        service: "CollectiveReadingCommentsService",
+        method: "checkAccess",
+        bookId,
+        userId,
+      });
+      ErrorHandler.log(normalizedError);
+      throw normalizedError;
+    }
+  }
+
+  async listByBookId(
+    bookId: string,
+    viewerUserId?: string,
+  ): Promise<CollectiveReadingCommentDomain[]> {
+    try {
+      const { data: rows, error } = await this.supabase
+        .from("collective_reading_comments")
+        .select("*")
+        .eq("book_id", bookId)
+        .order("created_at", { ascending: false });
+
+      if (error) {
+        throw new RepositoryError(
+          "Falha ao buscar comentários",
+          undefined,
+          undefined,
+          error,
+          { bookId },
+        );
+      }
+      if (!rows?.length) return [];
+
+      const commentIds = rows.map((r) => r.id as string);
+      const { data: reactionRows, error: reErr } = await this.supabase
+        .from("collective_reading_comment_reactions")
+        .select("comment_id, user_id, reaction")
+        .eq("book_id", bookId)
+        .in("comment_id", commentIds);
+
+      if (reErr) {
+        throw new RepositoryError(
+          "Falha ao buscar reações dos comentários",
+          undefined,
+          undefined,
+          reErr,
+          { bookId },
+        );
+      }
+
+      const statsByCommentId = this.buildReactionStatsByCommentId(
+        reactionRows ?? [],
+        viewerUserId,
+      );
+
+      const userIds = [...new Set(rows.map((r) => r.user_id as string))];
+      const { data: users, error: usersErr } = await this.supabase
+        .from("users")
+        .select("id, display_name")
+        .in("id", userIds);
+
+      if (usersErr) {
+        throw new RepositoryError(
+          "Falha ao resolver autores dos comentários",
+          undefined,
+          undefined,
+          usersErr,
+          { bookId },
+        );
+      }
+
+      const nameById = new Map(
+        (users ?? []).map((u) => [u.id as string, u.display_name as string]),
+      );
+
+      return (rows as CollectiveReadingCommentRow[]).map((row) =>
+        CollectiveReadingCommentMapper.toDomain(
+          row,
+          nameById.get(row.user_id) ?? "Leitor",
+          statsByCommentId.get(row.id),
+        ),
+      );
+    } catch (error) {
+      const normalizedError = ErrorHandler.normalize(error, {
+        service: "CollectiveReadingCommentsService",
+        method: "listByBookId",
+        bookId,
+      });
+      ErrorHandler.log(normalizedError);
+      throw normalizedError;
+    }
+  }
+
+  async createComment(
+    bookId: string,
+    content: string,
+  ): Promise<CollectiveReadingCommentDomain> {
+    try {
+      const rowRaw = await apiJson<CollectiveReadingCommentRow>(
+        "/api/collective-reading-comments",
+        {
+          method: "POST",
+          body: JSON.stringify({ bookId, content }),
+        },
+      );
+      const { data: userRow, error: userErr } = await this.supabase
+        .from("users")
+        .select("display_name")
+        .eq("id", rowRaw.user_id)
+        .maybeSingle();
+
+      if (userErr) {
+        throw new RepositoryError(
+          "Falha ao resolver autor do comentário",
+          undefined,
+          undefined,
+          userErr,
+          { bookId },
+        );
+      }
+
+      return CollectiveReadingCommentMapper.toDomain(
+        rowRaw,
+        userRow?.display_name ?? "Leitor",
+      );
+    } catch (error) {
+      const normalizedError = ErrorHandler.normalize(error, {
+        service: "CollectiveReadingCommentsService",
+        method: "createComment",
+        bookId,
+        content,
+      });
+      ErrorHandler.log(normalizedError);
+      throw normalizedError;
+    }
+  }
+
+  async removeComment(commentId: string): Promise<void> {
+    try {
+      await apiJson<{ ok: true }>(
+        `/api/collective-reading-comments/${encodeURIComponent(commentId)}`,
+        { method: "DELETE" },
+      );
+    } catch (error) {
+      const normalizedError = ErrorHandler.normalize(error, {
+        service: "CollectiveReadingCommentsService",
+        method: "removeComment",
+        commentId,
+      });
+      ErrorHandler.log(normalizedError);
+      throw normalizedError;
+    }
+  }
+
+  async setCommentReaction(
+    commentId: string,
+    reaction: CollectiveReadingCommentUserReaction,
+  ): Promise<CollectiveReadingCommentReactionResult> {
+    try {
+      return await apiJson<CollectiveReadingCommentReactionResult>(
+        "/api/collective-reading-comment-reactions",
+        {
+          method: "POST",
+          body: JSON.stringify({ commentId, reaction }),
+        },
+      );
+    } catch (error) {
+      const normalizedError = ErrorHandler.normalize(error, {
+        service: "CollectiveReadingCommentsService",
+        method: "setCommentReaction",
+        commentId,
+        reaction,
+      });
+      ErrorHandler.log(normalizedError);
+      throw normalizedError;
+    }
+  }
+}

--- a/src/modules/collectiveReading/services/mappers/collectiveReadingComment.mapper.ts
+++ b/src/modules/collectiveReading/services/mappers/collectiveReadingComment.mapper.ts
@@ -1,0 +1,38 @@
+import type {
+  CollectiveReadingCommentDomain,
+  CollectiveReadingCommentUserReaction,
+} from "../../types/collectiveReading.types";
+
+export type CollectiveReadingCommentRow = {
+  id: string;
+  book_id: string;
+  user_id: string;
+  content: string;
+  created_at: string;
+};
+
+export type CollectiveReadingCommentReactionStats = {
+  likeCount: number;
+  dislikeCount: number;
+  userReaction: CollectiveReadingCommentUserReaction;
+};
+
+export class CollectiveReadingCommentMapper {
+  static toDomain(
+    row: CollectiveReadingCommentRow,
+    authorDisplayName: string,
+    stats?: CollectiveReadingCommentReactionStats,
+  ): CollectiveReadingCommentDomain {
+    return {
+      id: row.id,
+      bookId: row.book_id,
+      userId: row.user_id,
+      content: row.content,
+      createdAt: row.created_at,
+      authorDisplayName,
+      likeCount: stats?.likeCount ?? 0,
+      dislikeCount: stats?.dislikeCount ?? 0,
+      userReaction: stats?.userReaction ?? null,
+    };
+  }
+}

--- a/src/modules/collectiveReading/types/collectiveReading.types.ts
+++ b/src/modules/collectiveReading/types/collectiveReading.types.ts
@@ -1,0 +1,51 @@
+export type CollectiveReadingCommentUserReaction =
+  | "like"
+  | "dislike"
+  | null;
+
+export type CollectiveReadingCommentDomain = {
+  id: string;
+  bookId: string;
+  userId: string;
+  content: string;
+  createdAt: string;
+  authorDisplayName: string;
+  likeCount: number;
+  dislikeCount: number;
+  userReaction: CollectiveReadingCommentUserReaction;
+};
+
+export type CollectiveReadingGateResult = {
+  canAccess: boolean;
+  bookTitle: string;
+  participantsDisplay: string;
+};
+
+export type ClientCollectiveReadingProps = {
+  id: string;
+  title: string;
+};
+
+export type CollectiveReadingCommentListProps = {
+  comments: CollectiveReadingCommentDomain[];
+  isLoading: boolean;
+  currentUserId: string | undefined;
+  reactionPendingCommentId: string | null;
+  onRequestDelete: (commentId: string) => void;
+  onToggleReaction: (
+    commentId: string,
+    value: "like" | "dislike",
+  ) => void;
+};
+
+export type CurrentScheduleChapterInfo =
+  | {
+      kind: "active";
+      dateLabel: string;
+      chaptersLabel: string;
+    }
+  | {
+      kind: "completed";
+      lastDateLabel: string;
+      lastChaptersLabel: string;
+    };

--- a/src/modules/collectiveReading/utils/collectiveReadingCommentQueryKey.ts
+++ b/src/modules/collectiveReading/utils/collectiveReadingCommentQueryKey.ts
@@ -1,0 +1,7 @@
+export function getCollectiveReadingCommentsQueryKey(bookId: string) {
+  return ["collective-reading-comments", bookId] as const;
+}
+
+export function getCollectiveReadingGateQueryKey(bookId: string, userId: string) {
+  return ["collective-reading-gate", "v2-participants", bookId, userId] as const;
+}

--- a/src/modules/collectiveReading/utils/currentScheduleChapter.test.ts
+++ b/src/modules/collectiveReading/utils/currentScheduleChapter.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import type { ScheduleDomain } from "@/modules/schedule/types/schedule.types";
+
+import { getCurrentScheduleChapterInfo } from "./currentScheduleChapter";
+
+describe("getCurrentScheduleChapterInfo", () => {
+  it("retorna null quando não há cronograma", () => {
+    expect(getCurrentScheduleChapterInfo(undefined)).toBeNull();
+    expect(getCurrentScheduleChapterInfo([])).toBeNull();
+  });
+
+  it("retorna o primeiro dia não concluído ordenado por data", () => {
+    const schedule: ScheduleDomain[] = [
+      {
+        id: "1",
+        owner: "u",
+        date: "2026-05-02T12:00:00.000Z",
+        chapters: "1-2",
+        completed: true,
+      },
+      {
+        id: "2",
+        owner: "u",
+        date: "2026-05-01T12:00:00.000Z",
+        chapters: "3",
+        completed: false,
+      },
+    ];
+    const info = getCurrentScheduleChapterInfo(schedule);
+    expect(info?.kind).toBe("active");
+    if (info?.kind === "active") {
+      expect(info.chaptersLabel).toBe("3");
+      expect(info.dateLabel).toBe("01/05/2026");
+    }
+  });
+
+  it("retorna completed quando todos os dias estão concluídos", () => {
+    const schedule: ScheduleDomain[] = [
+      {
+        id: "1",
+        owner: "u",
+        date: "2026-05-01T12:00:00.000Z",
+        chapters: "1",
+        completed: true,
+      },
+      {
+        id: "2",
+        owner: "u",
+        date: "2026-05-03T12:00:00.000Z",
+        chapters: "2",
+        completed: true,
+      },
+    ];
+    const info = getCurrentScheduleChapterInfo(schedule);
+    expect(info?.kind).toBe("completed");
+    if (info?.kind === "completed") {
+      expect(info.lastChaptersLabel).toBe("2");
+      expect(info.lastDateLabel).toBe("03/05/2026");
+    }
+  });
+});

--- a/src/modules/collectiveReading/utils/currentScheduleChapter.ts
+++ b/src/modules/collectiveReading/utils/currentScheduleChapter.ts
@@ -1,0 +1,28 @@
+import type { ScheduleDomain } from "@/modules/schedule/types/schedule.types";
+
+import type { CurrentScheduleChapterInfo } from "../types/collectiveReading.types";
+
+function formatScheduleDateLabel(isoDate: string) {
+  return isoDate.split("T")[0].split("-").reverse().join("/");
+}
+
+export function getCurrentScheduleChapterInfo(
+  schedule: ScheduleDomain[] | undefined,
+): CurrentScheduleChapterInfo | null {
+  if (!schedule?.length) return null;
+  const sorted = [...schedule].sort((a, b) => a.date.localeCompare(b.date));
+  const next = sorted.find((r) => !r.completed);
+  if (next) {
+    return {
+      kind: "active",
+      dateLabel: formatScheduleDateLabel(next.date),
+      chaptersLabel: next.chapters,
+    };
+  }
+  const last = sorted[sorted.length - 1];
+  return {
+    kind: "completed",
+    lastDateLabel: formatScheduleDateLabel(last.date),
+    lastChaptersLabel: last.chapters,
+  };
+}

--- a/src/services/books/books.mapper.test.ts
+++ b/src/services/books/books.mapper.test.ts
@@ -54,3 +54,20 @@ describe("BookMapper.isSoloBook", () => {
     ).toBe(false);
   });
 });
+
+describe("BookMapper.isCollectiveReadingBook", () => {
+  it("retorna true quando há mais de um leitor", () => {
+    expect(
+      BookMapper.isCollectiveReadingBook({
+        readerIds: ["a", "b"],
+      }),
+    ).toBe(true);
+  });
+
+  it("retorna false quando há zero ou um leitor", () => {
+    expect(BookMapper.isCollectiveReadingBook({ readerIds: [] })).toBe(false);
+    expect(BookMapper.isCollectiveReadingBook({ readerIds: ["a"] })).toBe(
+      false,
+    );
+  });
+});

--- a/src/services/books/books.mapper.ts
+++ b/src/services/books/books.mapper.ts
@@ -66,6 +66,12 @@ export class BookMapper {
     return readerIds.length === 1 && readerIds[0] === book.chosen_by;
   }
 
+  static isCollectiveReadingBook(
+    book: Pick<BookDomain, "readerIds">,
+  ): boolean {
+    return (book.readerIds?.length ?? 0) > 1;
+  }
+
   static enrichReadersDisplay(book: BookDomain, users: UserLookup[]): BookDomain {
     const ids = book.readerIds ?? [];
     return {

--- a/supabase/migrations/20260509120000_collective_reading_comments.sql
+++ b/supabase/migrations/20260509120000_collective_reading_comments.sql
@@ -1,0 +1,56 @@
+CREATE TABLE public.collective_reading_comments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  book_id uuid NOT NULL REFERENCES public.books (id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES public.users (id) ON DELETE CASCADE,
+  content text NOT NULL CHECK (length(trim(content)) > 0),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX collective_reading_comments_book_id_created_at_idx
+  ON public.collective_reading_comments (book_id, created_at DESC);
+
+ALTER TABLE public.collective_reading_comments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.collective_reading_comments FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY collective_reading_comments_select_participants
+  ON public.collective_reading_comments
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.books b
+      WHERE b.id = book_id
+        AND COALESCE(array_length(b.readers, 1), 0) > 1
+        AND (
+          (b.user_id IS NOT NULL AND auth.uid() = b.user_id)
+          OR auth.uid() = b.chosen_by
+          OR auth.uid() = ANY (COALESCE(b.readers, ARRAY[]::uuid[]))
+        )
+    )
+  );
+
+CREATE POLICY collective_reading_comments_select_anon
+  ON public.collective_reading_comments
+  FOR SELECT
+  TO anon
+  USING (false);
+
+CREATE POLICY collective_reading_comments_insert_participant
+  ON public.collective_reading_comments
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    user_id = auth.uid()
+    AND EXISTS (
+      SELECT 1
+      FROM public.books b
+      WHERE b.id = book_id
+        AND COALESCE(array_length(b.readers, 1), 0) > 1
+        AND (
+          (b.user_id IS NOT NULL AND auth.uid() = b.user_id)
+          OR auth.uid() = b.chosen_by
+          OR auth.uid() = ANY (COALESCE(b.readers, ARRAY[]::uuid[]))
+        )
+    )
+  );

--- a/supabase/migrations/20260510120000_collective_reading_comments_realtime.sql
+++ b/supabase/migrations/20260510120000_collective_reading_comments_realtime.sql
@@ -1,0 +1,1 @@
+ALTER PUBLICATION supabase_realtime ADD TABLE public.collective_reading_comments;

--- a/supabase/migrations/20260510200000_collective_reading_comments_delete_policy.sql
+++ b/supabase/migrations/20260510200000_collective_reading_comments_delete_policy.sql
@@ -1,0 +1,5 @@
+CREATE POLICY collective_reading_comments_delete_own
+  ON public.collective_reading_comments
+  FOR DELETE
+  TO authenticated
+  USING (user_id = auth.uid());

--- a/supabase/migrations/20260511140000_collective_reading_comment_reactions.sql
+++ b/supabase/migrations/20260511140000_collective_reading_comment_reactions.sql
@@ -1,0 +1,117 @@
+CREATE TABLE public.collective_reading_comment_reactions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  comment_id uuid NOT NULL REFERENCES public.collective_reading_comments (id) ON DELETE CASCADE,
+  book_id uuid NOT NULL REFERENCES public.books (id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES public.users (id) ON DELETE CASCADE,
+  reaction text NOT NULL CHECK (reaction IN ('like', 'dislike')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (comment_id, user_id)
+);
+
+CREATE INDEX collective_reading_comment_reactions_book_id_idx
+  ON public.collective_reading_comment_reactions (book_id);
+
+CREATE INDEX collective_reading_comment_reactions_comment_id_idx
+  ON public.collective_reading_comment_reactions (comment_id);
+
+CREATE OR REPLACE FUNCTION public.collective_reading_comment_reactions_set_book_id()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_book_id uuid;
+BEGIN
+  SELECT c.book_id INTO v_book_id
+  FROM public.collective_reading_comments c
+  WHERE c.id = NEW.comment_id;
+  IF v_book_id IS NULL THEN
+    RAISE EXCEPTION 'collective_reading_comment_reactions: comment not found';
+  END IF;
+  NEW.book_id := v_book_id;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS collective_reading_comment_reactions_set_book_id
+  ON public.collective_reading_comment_reactions;
+
+CREATE TRIGGER collective_reading_comment_reactions_set_book_id
+  BEFORE INSERT OR UPDATE OF comment_id ON public.collective_reading_comment_reactions
+  FOR EACH ROW
+  EXECUTE FUNCTION public.collective_reading_comment_reactions_set_book_id();
+
+ALTER TABLE public.collective_reading_comment_reactions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.collective_reading_comment_reactions FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY collective_reading_comment_reactions_select_participants
+  ON public.collective_reading_comment_reactions
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.books b
+      WHERE b.id = book_id
+        AND COALESCE(array_length(b.readers, 1), 0) > 1
+        AND (
+          (b.user_id IS NOT NULL AND auth.uid() = b.user_id)
+          OR auth.uid() = b.chosen_by
+          OR auth.uid() = ANY (COALESCE(b.readers, ARRAY[]::uuid[]))
+        )
+    )
+  );
+
+CREATE POLICY collective_reading_comment_reactions_select_anon
+  ON public.collective_reading_comment_reactions
+  FOR SELECT
+  TO anon
+  USING (false);
+
+CREATE POLICY collective_reading_comment_reactions_insert_participant
+  ON public.collective_reading_comment_reactions
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    user_id = auth.uid()
+    AND EXISTS (
+      SELECT 1
+      FROM public.books b
+      WHERE b.id = book_id
+        AND COALESCE(array_length(b.readers, 1), 0) > 1
+        AND (
+          (b.user_id IS NOT NULL AND auth.uid() = b.user_id)
+          OR auth.uid() = b.chosen_by
+          OR auth.uid() = ANY (COALESCE(b.readers, ARRAY[]::uuid[]))
+        )
+    )
+  );
+
+CREATE POLICY collective_reading_comment_reactions_update_own
+  ON public.collective_reading_comment_reactions
+  FOR UPDATE
+  TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (
+    user_id = auth.uid()
+    AND EXISTS (
+      SELECT 1
+      FROM public.books b
+      WHERE b.id = book_id
+        AND COALESCE(array_length(b.readers, 1), 0) > 1
+        AND (
+          (b.user_id IS NOT NULL AND auth.uid() = b.user_id)
+          OR auth.uid() = b.chosen_by
+          OR auth.uid() = ANY (COALESCE(b.readers, ARRAY[]::uuid[]))
+        )
+    )
+  );
+
+CREATE POLICY collective_reading_comment_reactions_delete_own
+  ON public.collective_reading_comment_reactions
+  FOR DELETE
+  TO authenticated
+  USING (user_id = auth.uid());
+
+ALTER PUBLICATION supabase_realtime ADD TABLE public.collective_reading_comment_reactions;


### PR DESCRIPTION
Tela de leitura coletiva com cronograma, comentários em tempo real, remoção pelo autor APIs REST e reações like/dislike com RLS e Realtime Migrações em supabase/migrations Link no BookCard registo em books mapper e bookParticipation para livros com mais de um leitor

## Summary by Sourcery

Add a dedicated collective reading experience for multi-reader books, including gated access, comments with like/dislike reactions, and real-time updates, wired into BookCard navigation and backed by Supabase RLS policies and migrations.

New Features:
- Introduce a collective reading screen for books with more than one reader, accessible from BookCard for eligible participants.
- Add REST APIs for creating, listing, and deleting collective reading comments, with per-author deletion control.
- Enable like/dislike reactions on collective reading comments, with per-user toggle behavior and aggregated counts.
- Provide schedule context on the collective reading screen by surfacing the user’s current or last reading schedule day.

Enhancements:
- Define shared rules and helpers to classify collective-reading books and validate user participation.
- Hook collective reading access checks into the book card logic and security layer based on readers configuration.
- Implement real-time synchronization of comments and reactions using Supabase Realtime and React Query cache updates.
- Improve checkbox UI styling for better default and dark-mode appearance.

Documentation:
- Document the collective reading module, route, APIs, and behavior in the main README, including real-time comments and reactions.

Tests:
- Add unit tests for collective-reading book classification logic.
- Add tests for comment and reaction API routes, covering auth, access control, and happy paths.
- Add tests for the collective reading schedule helper that derives the current or last chapter day.