### PR TITLE
feat(book-card): modal de detalhes, leitores no card e ações

### DIFF
--- a/src/components/bookCard/bookCard.test.tsx
+++ b/src/components/bookCard/bookCard.test.tsx
@@ -92,13 +92,20 @@ function presetUseBookCard(
     dialogDeleteModal: ModalMock;
     dialogEditModal: ModalMock;
     dropdownModal: ModalMock;
+    bookDetailsModal: ModalMock;
     showFavoriteToggle: boolean;
+    canAccessCollectiveReading: boolean;
     statusDisplay: {
       label: string;
       colorClass: string;
       dotClass: string;
     } | null;
     handleNavigateToAuthor: () => void;
+    handleOpenBookDetails: () => void;
+    handleAuthorSearchFromDetails: () => void;
+    handleCollectiveReadingFromDetails: () => void;
+    handleScheduleFromDetails: () => void;
+    handleQuotesFromDetails: () => void;
   }> = {},
 ) {
   const {
@@ -111,6 +118,11 @@ function presetUseBookCard(
       dotClass: "bg-amber-500",
     },
     handleNavigateToAuthor = vi.fn(),
+    handleOpenBookDetails = vi.fn(),
+    handleAuthorSearchFromDetails = vi.fn(),
+    handleCollectiveReadingFromDetails = vi.fn(),
+    handleScheduleFromDetails = vi.fn(),
+    handleQuotesFromDetails = vi.fn(),
   } = patch;
 
   const dialogDeleteModal =
@@ -118,6 +130,7 @@ function presetUseBookCard(
   const dialogEditModal = patch.dialogEditModal ?? modalState(false);
   const dialogAddShelfModal = patch.dialogAddShelfModal ?? modalState(false);
   const dropdownModal = patch.dropdownModal ?? modalState(false);
+  const bookDetailsModal = patch.bookDetailsModal ?? modalState(false);
 
   mockedUseBookCard.mockReturnValue({
     book,
@@ -125,6 +138,12 @@ function presetUseBookCard(
     dialogDeleteModal,
     dialogEditModal,
     dropdownModal,
+    bookDetailsModal,
+    handleOpenBookDetails,
+    handleAuthorSearchFromDetails,
+    handleCollectiveReadingFromDetails,
+    handleScheduleFromDetails,
+    handleQuotesFromDetails,
     dropdownTap: tapStub(),
     shareOnWhatsApp: vi.fn(),
     handleNavigateToSchedule: vi.fn(),
@@ -137,6 +156,13 @@ function presetUseBookCard(
     showFavoriteToggle: patch.showFavoriteToggle ?? false,
     handleFavoriteClick: vi.fn(),
     isFavoritePending: false,
+    canAccessCollectiveReading: patch.canAccessCollectiveReading ?? false,
+    collectiveReadingHref: "/collective-reading/book-1/Mem%C3%B3rias%20P%C3%B3stumas",
+    handleNavigateToCollectiveReading: vi.fn(),
+    badgeObject: {
+      bookStatusClass: "bg-green-800 text-white",
+      bookStatusText: "Já iniciei a leitura",
+    },
   } as unknown as ReturnType<typeof useBookCard>);
 }
 
@@ -150,12 +176,20 @@ describe("BookCard", () => {
     render(<BookCard book={baseBook} />);
 
     expect(screen.getByText("Memórias Póstumas")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", {
-        name: "Autor: Machado de Assis — Memórias Póstumas",
-      }),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Machado de Assis")).toBeInTheDocument();
     expect(screen.getByText("Lendo agora")).toBeInTheDocument();
+  });
+
+  it("clique no alvo principal do card chama abertura do modal de detalhes", () => {
+    const handleOpenBookDetails = vi.fn();
+    presetUseBookCard(baseBook, { handleOpenBookDetails });
+    render(<BookCard book={baseBook} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Ver detalhes: Memórias Póstumas/i }),
+    );
+
+    expect(handleOpenBookDetails).toHaveBeenCalledTimes(1);
   });
 
   it("RN20: sem sessão, não exibe o menu de mais opções", () => {
@@ -169,6 +203,19 @@ describe("BookCard", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("sem sessão, não exibe nomes de leitores mesmo se readersDisplay vier preenchido", () => {
+    const book = {
+      ...baseBook,
+      readersDisplay: "be1cb368-a253-489b-8615-c88d06c0ff00",
+    };
+    presetUseBookCard(book, { isLogged: false });
+    render(<BookCard book={book} />);
+
+    expect(
+      screen.queryByText("be1cb368-a253-489b-8615-c88d06c0ff00"),
+    ).not.toBeInTheDocument();
+  });
+
   it("com sessão, exibe o menu de mais opções (alvo tocável ampliado)", () => {
     presetUseBookCard(baseBook, { isLogged: true });
     const { container } = render(<BookCard book={baseBook} />);
@@ -179,7 +226,7 @@ describe("BookCard", () => {
     expect(moreBtn).toBeInTheDocument();
     expect(moreBtn.className).toMatch(/w-11/);
     expect(moreBtn.className).toMatch(/h-11/);
-    expect(container.querySelector('img[alt="Memórias Póstumas"]')).toBeTruthy();
+    expect(container.querySelector("img")).toBeTruthy();
   });
 
   it("RN55: na estante, o diálogo de remoção descreve apenas o vínculo com a estante", () => {
@@ -206,28 +253,17 @@ describe("BookCard", () => {
     expect(screen.getByText("Deseja excluir este livro?")).toBeInTheDocument();
   });
 
-  it("RN56: exibe selo Privado quando o hook indica livro individual do usuário", () => {
-    presetUseBookCard(baseBook, { isOwnSoloBook: true });
+  it("RN56: exibe selo Privado no modal de detalhes quando o hook indica livro individual", () => {
+    presetUseBookCard(baseBook, {
+      isOwnSoloBook: true,
+      bookDetailsModal: modalState(true),
+    });
     render(<BookCard book={baseBook} />);
 
     expect(
       screen.getByLabelText("Livro privado — visível apenas para você"),
     ).toBeInTheDocument();
     expect(screen.getByText("Privado")).toBeInTheDocument();
-  });
-
-  it("dispara navegação ao autor ao clicar no botão do autor", () => {
-    const handleNavigateToAuthor = vi.fn();
-    presetUseBookCard(baseBook, { handleNavigateToAuthor });
-    render(<BookCard book={baseBook} />);
-
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Autor: Machado de Assis — Memórias Póstumas",
-      }),
-    );
-
-    expect(handleNavigateToAuthor).toHaveBeenCalledTimes(1);
   });
 
   it("no contexto de estante, reduz o alvo tocável do menu (RN15 contexto denso)", () => {
@@ -242,13 +278,13 @@ describe("BookCard", () => {
     expect(moreBtn.className).toMatch(/h-8/);
   });
 
-  it("exibe selo Releitura e chip de gênero quando o livro traz esses campos", () => {
+  it("exibe selo Releitura e chip de gênero no modal quando o livro traz esses campos", () => {
     const book = {
       ...baseBook,
       is_reread: true,
       gender: "romance" as const,
     };
-    presetUseBookCard(book);
+    presetUseBookCard(book, { bookDetailsModal: modalState(true) });
     render(<BookCard book={book} />);
 
     expect(screen.getByText("Releitura")).toBeInTheDocument();

--- a/src/components/bookCard/bookCard.tsx
+++ b/src/components/bookCard/bookCard.tsx
@@ -1,24 +1,23 @@
 "use client";
 
 import Image from "next/image";
-import Link from "next/link";
-import { BookOpen, EllipsisVerticalIcon, Heart, Lock, Users } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent } from "@/components/ui/card";
+import { EllipsisVerticalIcon, Heart, Users } from "lucide-react";
+
+import BookCardDetailsModal from "./components/bookCardDetailsModal";
+import { AddBookToShelf } from "./components/addBookToShelf";
+import { DropdownBook } from "./components/dropdownBook";
+import { BookUpsert } from "@/modules/bookUpsert";
+import { ConfirmDialog } from "@/components/confirmDialog";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { DropdownBook } from "./components/dropdownBook";
-import { BookUpsert } from "@/modules/bookUpsert";
-import { ConfirmDialog } from "@/components/confirmDialog";
-import { AddBookToShelf } from "./components/addBookToShelf";
+import { Card, CardContent } from "@/components/ui/card";
 import { useBookCard } from "./hooks/useBookCard";
 import { BookCardProps } from "./types/bookCard.types";
-import { getGenderLabel, getGenreBadgeColor } from "@/constants/genders";
-import { cn } from "@/lib/utils";
 import { resolveBookCoverUrl } from "@/constants/bookCover";
+import { cn } from "@/lib/utils";
 
 export function BookCard(props: BookCardProps) {
   const { isShelf = false, hideInteractions = false } = props;
@@ -28,12 +27,17 @@ export function BookCard(props: BookCardProps) {
     dialogDeleteModal,
     dialogEditModal,
     dropdownModal,
+    bookDetailsModal,
+    handleOpenBookDetails,
+    handleAuthorSearchFromDetails,
+    handleCollectiveReadingFromDetails,
+    handleScheduleFromDetails,
+    handleQuotesFromDetails,
     dropdownTap,
     shareOnWhatsApp,
     handleNavigateToSchedule,
-    handleNavigateToAuthor,
-    isLogged,
     handleNavigateToQuotes,
+    isLogged,
     handleConfirmDelete,
     statusDisplay,
     isOwnSoloBook,
@@ -41,27 +45,49 @@ export function BookCard(props: BookCardProps) {
     handleFavoriteClick,
     isFavoritePending,
     canAccessCollectiveReading,
-    collectiveReadingHref,
   } = useBookCard(props);
 
   const showTopActions =
     showFavoriteToggle || (isLogged && !hideInteractions);
+  const showReadersOnCard =
+    isLogged && Boolean(book.readersDisplay?.trim());
 
-  const bookBody = (
-    <>
+  const coverSizes = isShelf
+    ? { width: 56, height: 92, className: "relative h-[92px] w-14 shrink-0 overflow-hidden rounded-md bg-muted/20 shadow-sm" }
+    : { width: 90, height: 130, className: "relative h-[130px] w-[90px] shrink-0 overflow-hidden rounded-md shadow-sm" };
+
+  const bookMain = (
+    <button
+      type="button"
+      onClick={handleOpenBookDetails}
+      className={cn(
+        "flex min-w-0 flex-1 cursor-pointer gap-3 rounded-md border-0 bg-transparent p-0 text-left transition-opacity duration-200 hover:opacity-95 active:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400/80 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-50 dark:focus-visible:ring-zinc-500 dark:focus-visible:ring-offset-zinc-950",
+        isShelf ? "gap-2.5" : "gap-3",
+      )}
+      aria-label={`Ver detalhes: ${book.title}`}
+    >
+      <div className={coverSizes.className}>
+        <Image
+          src={resolveBookCoverUrl(book.image_url)}
+          alt=""
+          width={coverSizes.width}
+          height={coverSizes.height}
+          className="size-full object-cover"
+          loading="lazy"
+        />
+      </div>
       <div
         className={cn(
-          "flex min-w-0 gap-2",
-          showTopActions ? "items-start" : "items-stretch",
-          isShelf ? "mb-0.5" : "mb-1",
+          "flex min-w-0 flex-1 flex-col",
+          isShelf ? "min-h-[92px] gap-1" : "min-h-[130px] gap-1.5",
         )}
       >
         <Tooltip>
           <TooltipTrigger asChild>
             <p
               className={cn(
-                "min-w-0 flex-1 cursor-default font-semibold leading-snug line-clamp-2 text-left text-zinc-900 dark:text-zinc-100",
-                isShelf ? "text-xs pr-1" : "text-sm pr-1",
+                "min-w-0 font-semibold leading-snug text-zinc-900 line-clamp-2 dark:text-zinc-100",
+                isShelf ? "text-xs" : "text-sm",
               )}
             >
               {book.title}
@@ -71,232 +97,73 @@ export function BookCard(props: BookCardProps) {
             {book.title}
           </TooltipContent>
         </Tooltip>
-        {showTopActions && (
-          <div className="flex shrink-0 items-center gap-0.5 pt-px">
-            {showFavoriteToggle && (
-              <button
-                type="button"
-                onClick={handleFavoriteClick}
-                disabled={isFavoritePending}
-                title={
-                  book.is_favorite
-                    ? "Remover dos favoritos (também no menu ⋮)"
-                    : "Marcar como favorito (também no menu ⋮)"
-                }
-                aria-label={
-                  book.is_favorite
-                    ? `Remover "${book.title}" dos favoritos`
-                    : `Marcar "${book.title}" como favorito`
-                }
-                aria-pressed={book.is_favorite}
+
+        <p
+          className={cn(
+            "truncate text-zinc-600 dark:text-zinc-400",
+            isShelf ? "text-[11px]" : "text-xs",
+          )}
+        >
+          {book.author}
+        </p>
+
+        {(showReadersOnCard || statusDisplay) && (
+          <div
+            className={cn(
+              "mt-auto flex min-w-0 flex-col",
+              isShelf ? "gap-1" : "gap-1.5",
+            )}
+          >
+            {showReadersOnCard && (
+              <span className="flex min-w-0 items-center gap-1 text-[11px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+                <Users aria-hidden className="size-2.5 shrink-0" />
+                <span className="truncate">{book.readersDisplay}</span>
+              </span>
+            )}
+            {statusDisplay && (
+              <span
                 className={cn(
-                  "flex items-center justify-center rounded-full border transition-colors duration-200 cursor-pointer disabled:opacity-60",
-                  isShelf ? "w-7 h-7" : "w-9 h-9",
-                  book.is_favorite
-                    ? "border-rose-200 bg-rose-50 text-rose-500 hover:bg-rose-100 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-400 dark:hover:bg-rose-950/60"
-                    : "border-zinc-200 bg-zinc-50/80 text-zinc-400 hover:border-rose-200 hover:text-rose-500 dark:border-zinc-700 dark:bg-zinc-800/50 dark:text-zinc-400 dark:hover:border-rose-800 dark:hover:text-rose-400",
+                  "inline-flex w-fit items-center gap-1 rounded-full font-semibold",
+                  isShelf
+                    ? "h-4 gap-0.5 px-1.5 py-0 text-[9px]"
+                    : "px-2 py-0.5 text-[10px]",
+                  statusDisplay.colorClass,
                 )}
               >
-                <Heart
+                <span
                   className={cn(
-                    isShelf ? "w-3 h-3" : "w-4 h-4",
-                    book.is_favorite && "fill-current",
+                    "shrink-0 rounded-full",
+                    isShelf ? "h-1 w-1" : "h-1.5 w-1.5",
+                    statusDisplay.dotClass,
                   )}
-                  aria-hidden
                 />
-              </button>
-            )}
-            {isLogged && !hideInteractions && (
-              <DropdownBook
-                isOpen={dropdownModal.isOpen}
-                onOpenChange={dropdownModal.setIsOpen}
-                onToggleFavorite={() => handleFavoriteClick()}
-                isFavorite={book.is_favorite}
-                favoriteActionBusy={isFavoritePending}
-                trigger={
-                  <button
-                    type="button"
-                    aria-label={`Mais opções para "${book.title}"`}
-                    className={cn(
-                      "flex shrink-0 items-center justify-center rounded-full transition-colors duration-200 cursor-pointer hover:bg-zinc-100 dark:hover:bg-zinc-800 active:opacity-70",
-                      isShelf ? "h-8 w-8" : "h-11 w-11",
-                    )}
-                  >
-                    <EllipsisVerticalIcon
-                      className={cn(
-                        "text-zinc-400",
-                        isShelf ? "size-3.5" : "size-4",
-                      )}
-                      aria-hidden
-                      onTouchStart={dropdownTap.handleTouchStart}
-                      onTouchEnd={dropdownTap.handleTouchEnd}
-                      onClick={dropdownTap.handleClick}
-                    />
-                  </button>
-                }
-                editBook={() => dialogEditModal.setIsOpen(true)}
-                removeBook={() => dialogDeleteModal.setIsOpen(true)}
-                removeBookLabel={
-                  isShelf ? "Remover livro da estante" : "Remover livro"
-                }
-                addToShelf={() => dialogAddShelfModal.setIsOpen(true)}
-                shareOnWhatsApp={shareOnWhatsApp}
-                schedule={handleNavigateToSchedule}
-                quotes={handleNavigateToQuotes}
-                isFinishedReading={book.status === "finished"}
-                quotesDisabled={book.status !== "not_started"}
-              />
+                {statusDisplay.label}
+              </span>
             )}
           </div>
         )}
       </div>
-
-      <button
-        type="button"
-        onClick={handleNavigateToAuthor}
-        aria-label={`Autor: ${book.author} — ${book.title}`}
-        className={cn(
-          "text-blue-600 dark:text-blue-400 truncate text-left cursor-pointer underline-offset-2 transition-colors duration-200 hover:underline active:opacity-70",
-          isShelf ? "text-[11px] mb-1" : "text-xs mb-2",
-        )}
-      >
-        {book.author}
-      </button>
-
-      <div
-        className={cn("flex flex-col mt-auto", isShelf ? "gap-1" : "gap-1.5")}
-      >
-        {statusDisplay && (
-          <span
-            className={cn(
-              "inline-flex w-fit items-center gap-1 rounded-full font-semibold",
-              isShelf
-                ? "h-4 gap-0.5 px-1.5 text-[9px] py-0"
-                : "px-2 py-0.5 text-[10px]",
-              statusDisplay.colorClass,
-            )}
-          >
-            <span
-              className={cn(
-                "shrink-0 rounded-full",
-                isShelf ? "h-1 w-1" : "w-1.5 h-1.5",
-                statusDisplay.dotClass,
-              )}
-            />
-            {statusDisplay.label}
-          </span>
-        )}
-        {isShelf === false && (
-          <div className="flex items-center gap-2 text-[11px] text-zinc-400 dark:text-zinc-500">
-            {book.readersDisplay && (
-              <span className="flex items-center gap-1 shrink-0">
-                <Users size={10} className="shrink-0" />
-                <span>{book.readersDisplay}</span>
-              </span>
-            )}
-            {book.readersDisplay && book.pages && (
-              <span className="text-zinc-300 dark:text-zinc-600 select-none">
-                ·
-              </span>
-            )}
-            {book.pages && (
-              <span className="flex items-center gap-1 shrink-0">
-                <BookOpen size={10} className="shrink-0" />
-                <span>{book.pages} páginas</span>
-              </span>
-            )}
-          </div>
-        )}
-
-        {isShelf === true && (
-          <div className="flex items-center gap-2 text-[11px] text-zinc-400 dark:text-zinc-500">
-            {book.readersDisplay && (
-              <span className="flex shrink-0 items-center gap-1">
-                <Users size={10} className="shrink-0" />
-                <span>{book.readersDisplay}</span>
-              </span>
-            )}
-            {book.readersDisplay && book.pages && (
-              <span className="select-none text-zinc-300 dark:text-zinc-600">
-                ·
-              </span>
-            )}
-            {book.pages && (
-              <span className="flex shrink-0 items-center gap-1">
-                <BookOpen size={10} className="shrink-0" />
-                <span>{book.pages} páginas</span>
-              </span>
-            )}
-          </div>
-        )}
-
-        {canAccessCollectiveReading && (
-          <Link
-            href={collectiveReadingHref}
-            className={cn(
-              "w-fit text-xs font-medium text-violet-600 underline-offset-2 hover:underline dark:text-violet-400 cursor-pointer",
-              isShelf ? "mt-0.5" : "mt-1",
-            )}
-          >
-            Leitura coletiva
-          </Link>
-        )}
-
-        {isOwnSoloBook && (
-          <Badge
-            variant="secondary"
-            aria-label="Livro privado — visível apenas para você"
-            className={cn(
-              "w-fit border-none font-medium uppercase",
-              isShelf
-                ? "h-4 px-1.5 text-[9px] py-0 gap-0.5"
-                : "h-5 px-2 text-[10px] py-0 gap-1",
-              "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400",
-            )}
-          >
-            <Lock
-              aria-hidden
-              className={cn(isShelf ? "w-2 h-2" : "w-2.5 h-2.5")}
-            />
-            Privado
-          </Badge>
-        )}
-
-        {book.is_reread && (
-          <Badge
-            variant="secondary"
-            className={cn(
-              "w-fit border-none font-medium uppercase",
-              isShelf
-                ? "h-4 px-1.5 text-[9px] py-0"
-                : "h-5 px-2 text-[10px] py-0",
-              "bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300",
-            )}
-          >
-            Releitura
-          </Badge>
-        )}
-
-        {book.gender && (
-          <Badge
-            variant="secondary"
-            className={cn(
-              "w-fit border-none font-medium uppercase",
-              isShelf
-                ? "h-4 px-1.5 text-[9px] py-0"
-                : "h-5 px-2 text-[10px] py-0",
-              getGenreBadgeColor(book.gender),
-            )}
-          >
-            {getGenderLabel(book.gender)}
-          </Badge>
-        )}
-      </div>
-    </>
+    </button>
   );
 
   return (
     <>
+      <BookCardDetailsModal
+        open={bookDetailsModal.isOpen}
+        onOpenChange={bookDetailsModal.setIsOpen}
+        book={book}
+        statusDisplay={statusDisplay}
+        isLogged={isLogged}
+        isOwnSoloBook={isOwnSoloBook}
+        canAccessCollectiveReading={canAccessCollectiveReading}
+        scheduleDisabled={book.status === "finished"}
+        quotesDisabled={book.status === "not_started"}
+        onAuthorSearch={handleAuthorSearchFromDetails}
+        onCollectiveReading={handleCollectiveReadingFromDetails}
+        onOpenSchedule={handleScheduleFromDetails}
+        onOpenQuotes={handleQuotesFromDetails}
+      />
+
       <AddBookToShelf
         isOpen={dialogAddShelfModal.isOpen}
         handleClose={dialogAddShelfModal.setIsOpen}
@@ -333,40 +200,96 @@ export function BookCard(props: BookCardProps) {
         )}
       >
         <CardContent className={cn(isShelf ? "p-2" : "p-3")}>
-          {isShelf ? (
-            <div className="flex gap-2.5">
-              <div className="relative h-[92px] w-14 shrink-0 overflow-hidden rounded-md bg-muted/20 shadow-sm">
-                <Image
-                  src={resolveBookCoverUrl(book.image_url)}
-                  alt={book.title}
-                  width={56}
-                  height={92}
-                  className="object-cover size-full"
-                  loading="lazy"
-                />
+          <div
+            className={cn("flex min-w-0", isShelf ? "gap-2.5" : "gap-3")}
+          >
+            {bookMain}
+            {showTopActions && (
+              <div
+                className={cn(
+                  "flex shrink-0 flex-col items-end gap-0.5",
+                  isShelf ? "pt-px" : "pt-px",
+                )}
+                onClick={(e) => e.stopPropagation()}
+                onKeyDown={(e) => e.stopPropagation()}
+              >
+                {showFavoriteToggle && (
+                  <button
+                    type="button"
+                    onClick={handleFavoriteClick}
+                    disabled={isFavoritePending}
+                    title={
+                      book.is_favorite
+                        ? "Remover dos favoritos (também no menu ⋮)"
+                        : "Marcar como favorito (também no menu ⋮)"
+                    }
+                    aria-label={
+                      book.is_favorite
+                        ? `Remover "${book.title}" dos favoritos`
+                        : `Marcar "${book.title}" como favorito`
+                    }
+                    aria-pressed={book.is_favorite}
+                    className={cn(
+                      "flex cursor-pointer items-center justify-center rounded-full border transition-colors duration-200 disabled:opacity-60",
+                      isShelf ? "h-7 w-7" : "h-9 w-9",
+                      book.is_favorite
+                        ? "border-rose-200 bg-rose-50 text-rose-500 hover:bg-rose-100 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-400 dark:hover:bg-rose-950/60"
+                        : "border-zinc-200 bg-zinc-50/80 text-zinc-400 hover:border-rose-200 hover:text-rose-500 dark:border-zinc-700 dark:bg-zinc-800/50 dark:text-zinc-400 dark:hover:border-rose-800 dark:hover:text-rose-400",
+                    )}
+                  >
+                    <Heart
+                      className={cn(
+                        isShelf ? "h-3 w-3" : "h-4 w-4",
+                        book.is_favorite && "fill-current",
+                      )}
+                      aria-hidden
+                    />
+                  </button>
+                )}
+                {isLogged && !hideInteractions && (
+                  <DropdownBook
+                    isOpen={dropdownModal.isOpen}
+                    onOpenChange={dropdownModal.setIsOpen}
+                    onToggleFavorite={() => handleFavoriteClick()}
+                    isFavorite={book.is_favorite}
+                    favoriteActionBusy={isFavoritePending}
+                    trigger={
+                      <button
+                        type="button"
+                        aria-label={`Mais opções para "${book.title}"`}
+                        className={cn(
+                          "flex shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors duration-200 hover:bg-zinc-100 active:opacity-70 dark:hover:bg-zinc-800",
+                          isShelf ? "h-8 w-8" : "h-11 w-11",
+                        )}
+                      >
+                        <EllipsisVerticalIcon
+                          className={cn(
+                            "text-zinc-400",
+                            isShelf ? "size-3.5" : "size-4",
+                          )}
+                          aria-hidden
+                          onTouchStart={dropdownTap.handleTouchStart}
+                          onTouchEnd={dropdownTap.handleTouchEnd}
+                          onClick={dropdownTap.handleClick}
+                        />
+                      </button>
+                    }
+                    editBook={() => dialogEditModal.setIsOpen(true)}
+                    removeBook={() => dialogDeleteModal.setIsOpen(true)}
+                    removeBookLabel={
+                      isShelf ? "Remover livro da estante" : "Remover livro"
+                    }
+                    addToShelf={() => dialogAddShelfModal.setIsOpen(true)}
+                    shareOnWhatsApp={shareOnWhatsApp}
+                    schedule={handleNavigateToSchedule}
+                    quotes={handleNavigateToQuotes}
+                    isFinishedReading={book.status === "finished"}
+                    quotesDisabled={book.status !== "not_started"}
+                  />
+                )}
               </div>
-              <div className="flex min-h-[92px] min-w-0 flex-1 flex-col">
-                {bookBody}
-              </div>
-            </div>
-          ) : (
-            <div className="flex gap-3">
-              <div className="relative shrink-0 w-[90px] h-[130px] rounded-md overflow-hidden shadow-sm">
-                <Image
-                  src={resolveBookCoverUrl(book.image_url)}
-                  alt={book.title}
-                  width={90}
-                  height={130}
-                  className="object-cover size-full"
-                  loading="lazy"
-                />
-              </div>
-
-              <div className="flex min-h-[130px] min-w-0 flex-1 flex-col">
-                {bookBody}
-              </div>
-            </div>
-          )}
+            )}
+          </div>
         </CardContent>
       </Card>
     </>

--- a/src/components/bookCard/components/bookCardDetailsModal/bookCardDetailsModal.tsx
+++ b/src/components/bookCard/components/bookCardDetailsModal/bookCardDetailsModal.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import Image from "next/image";
+import {
+  BookMarked,
+  CalendarDays,
+  Heart,
+  Lock,
+  MessageSquareQuote,
+  Users,
+} from "lucide-react";
+import { useMemo } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { getGenderLabel, getGenreBadgeColor } from "@/constants/genders";
+import { resolveBookCoverUrl } from "@/constants/bookCover";
+import { cn } from "@/lib/utils";
+
+import type { BookCardDetailsModalProps } from "./types/bookCardDetailsModal.types";
+
+function formatPtDate(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+export default function BookCardDetailsModal({
+  open,
+  onOpenChange,
+  book,
+  statusDisplay,
+  isLogged,
+  isOwnSoloBook,
+  canAccessCollectiveReading,
+  scheduleDisabled,
+  quotesDisabled,
+  onAuthorSearch,
+  onCollectiveReading,
+  onOpenSchedule,
+  onOpenQuotes,
+}: BookCardDetailsModalProps) {
+  const plannedLabel = useMemo(
+    () => formatPtDate(book.planned_start_date),
+    [book.planned_start_date],
+  );
+  const startLabel = useMemo(() => formatPtDate(book.start_date), [book.start_date]);
+  const endLabel = useMemo(() => formatPtDate(book.end_date), [book.end_date]);
+
+  const showReaders = isLogged && Boolean(book.readersDisplay?.trim());
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton
+        className="max-h-[min(85vh,calc(100dvh-2rem))] gap-0 overflow-y-auto p-0 sm:max-w-lg"
+      >
+        <div className="flex flex-col gap-4 p-6 pt-8">
+          <DialogHeader className="gap-2 text-left">
+            <DialogTitle className="text-balance pr-8 text-base leading-snug sm:text-lg">
+              {book.title}
+            </DialogTitle>
+            <DialogDescription className="text-left text-zinc-600 dark:text-zinc-400">
+              {book.author}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+            <div className="relative mx-auto shrink-0 overflow-hidden rounded-md shadow-sm sm:mx-0">
+              <Image
+                src={resolveBookCoverUrl(book.image_url)}
+                alt={book.title}
+                width={120}
+                height={173}
+                className="object-cover"
+                loading="lazy"
+              />
+            </div>
+
+            <div className="flex min-w-0 flex-1 flex-col gap-3">
+              {statusDisplay && (
+                <span
+                  className={cn(
+                    "inline-flex w-fit items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold",
+                    statusDisplay.colorClass,
+                  )}
+                >
+                  <span
+                    className={cn("h-1.5 w-1.5 shrink-0 rounded-full", statusDisplay.dotClass)}
+                  />
+                  {statusDisplay.label}
+                </span>
+              )}
+
+              <div className="flex flex-wrap gap-2">
+                {isOwnSoloBook && (
+                  <Badge
+                    variant="secondary"
+                    aria-label="Livro privado — visível apenas para você"
+                    className="w-fit gap-1 border-none bg-zinc-100 font-medium uppercase text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
+                  >
+                    <Lock aria-hidden className="size-2.5" />
+                    Privado
+                  </Badge>
+                )}
+                {book.is_favorite && (
+                  <Badge
+                    variant="secondary"
+                    className="w-fit gap-1 border-none bg-rose-100 font-medium uppercase text-rose-700 dark:bg-rose-950/50 dark:text-rose-400"
+                  >
+                    <Heart aria-hidden className="size-2.5 fill-current" />
+                    Favorito
+                  </Badge>
+                )}
+                {book.is_reread && (
+                  <Badge
+                    variant="secondary"
+                    className="w-fit border-none bg-violet-100 font-medium uppercase text-violet-700 dark:bg-violet-900/30 dark:text-violet-300"
+                  >
+                    Releitura
+                  </Badge>
+                )}
+                {book.gender && (
+                  <Badge
+                    variant="secondary"
+                    className={cn(
+                      "w-fit border-none font-medium uppercase",
+                      getGenreBadgeColor(book.gender),
+                    )}
+                  >
+                    {getGenderLabel(book.gender)}
+                  </Badge>
+                )}
+              </div>
+
+              <dl className="grid gap-2.5 text-sm">
+                <div className="grid grid-cols-[minmax(0,7rem)_1fr] gap-x-3 gap-y-1">
+                  <dt className="text-zinc-500 dark:text-zinc-400">Páginas</dt>
+                  <dd className="font-medium text-zinc-900 dark:text-zinc-100">{book.pages}</dd>
+                </div>
+                {plannedLabel && (
+                  <div className="grid grid-cols-[minmax(0,7rem)_1fr] gap-x-3 gap-y-1">
+                    <dt className="text-zinc-500 dark:text-zinc-400">Início planejado</dt>
+                    <dd className="font-medium text-zinc-900 dark:text-zinc-100">
+                      {plannedLabel}
+                    </dd>
+                  </div>
+                )}
+                {startLabel && (
+                  <div className="grid grid-cols-[minmax(0,7rem)_1fr] gap-x-3 gap-y-1">
+                    <dt className="text-zinc-500 dark:text-zinc-400">Leitura iniciada</dt>
+                    <dd className="font-medium text-zinc-900 dark:text-zinc-100">
+                      {startLabel}
+                    </dd>
+                  </div>
+                )}
+                {endLabel && (
+                  <div className="grid grid-cols-[minmax(0,7rem)_1fr] gap-x-3 gap-y-1">
+                    <dt className="text-zinc-500 dark:text-zinc-400">Concluído em</dt>
+                    <dd className="font-medium text-zinc-900 dark:text-zinc-100">{endLabel}</dd>
+                  </div>
+                )}
+                {showReaders && (
+                  <div className="grid grid-cols-[minmax(0,7rem)_1fr] gap-x-3 gap-y-1">
+                    <dt className="flex items-center gap-1 text-zinc-500 dark:text-zinc-400">
+                      <Users aria-hidden className="size-3.5 shrink-0" />
+                      Leitores
+                    </dt>
+                    <dd className="min-w-0 font-medium wrap-break-word text-zinc-900 dark:text-zinc-100">
+                      {book.readersDisplay}
+                    </dd>
+                  </div>
+                )}
+              </dl>
+
+              <div className="flex flex-col gap-2 pt-1 sm:flex-row sm:flex-wrap">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="w-full cursor-pointer transition-colors duration-200 sm:w-auto"
+                  onClick={onAuthorSearch}
+                >
+                  Buscar por autor
+                </Button>
+                {isLogged && (
+                  <>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={scheduleDisabled}
+                      title={
+                        scheduleDisabled
+                          ? "Cronograma indisponível para livros finalizados"
+                          : undefined
+                      }
+                      className="w-full cursor-pointer gap-1.5 transition-colors duration-200 sm:w-auto"
+                      onClick={onOpenSchedule}
+                    >
+                      <CalendarDays aria-hidden className="size-3.5" />
+                      Cronograma
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={quotesDisabled}
+                      title={
+                        quotesDisabled
+                          ? "Citações ficam disponíveis após iniciar a leitura"
+                          : undefined
+                      }
+                      className="w-full cursor-pointer gap-1.5 transition-colors duration-200 sm:w-auto"
+                      onClick={onOpenQuotes}
+                    >
+                      <MessageSquareQuote aria-hidden className="size-3.5" />
+                      Citações
+                    </Button>
+                  </>
+                )}
+                {canAccessCollectiveReading && (
+                  <Button
+                    type="button"
+                    size="sm"
+                    className="w-full cursor-pointer gap-1.5 bg-violet-600 text-white transition-colors duration-200 hover:bg-violet-700 sm:w-auto"
+                    onClick={onCollectiveReading}
+                  >
+                    <BookMarked aria-hidden className="size-3.5" />
+                    Leitura coletiva
+                  </Button>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/bookCard/components/bookCardDetailsModal/index.ts
+++ b/src/components/bookCard/components/bookCardDetailsModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./bookCardDetailsModal";

--- a/src/components/bookCard/components/bookCardDetailsModal/types/bookCardDetailsModal.types.ts
+++ b/src/components/bookCard/components/bookCardDetailsModal/types/bookCardDetailsModal.types.ts
@@ -1,0 +1,19 @@
+import type { BookDomain } from "@/types/books.types";
+
+import type { StatusDisplay } from "../../../types/bookCard.types";
+
+export type BookCardDetailsModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  book: BookDomain;
+  statusDisplay: StatusDisplay;
+  isLogged: boolean;
+  isOwnSoloBook: boolean;
+  canAccessCollectiveReading: boolean;
+  scheduleDisabled: boolean;
+  quotesDisabled: boolean;
+  onAuthorSearch: () => void;
+  onCollectiveReading: () => void;
+  onOpenSchedule: () => void;
+  onOpenQuotes: () => void;
+};

--- a/src/components/bookCard/hooks/useBookCard.ts
+++ b/src/components/bookCard/hooks/useBookCard.ts
@@ -21,6 +21,7 @@ export function useBookCard({
   const dialogEditModal = useModal();
   const dialogDeleteModal = useModal();
   const dialogAddShelfModal = useModal();
+  const bookDetailsModal = useModal();
 
   const router = useRouter();
   const isLogged = useIsLoggedIn();
@@ -71,6 +72,34 @@ export function useBookCard({
   const handleNavigateToQuotes = useCallback(() => {
     router.push(`/quotes/${book.title}/${book.id}`);
   }, [router, book.title, book.id]);
+
+  const handleNavigateToCollectiveReading = useCallback(() => {
+    router.push(collectiveReadingHref);
+  }, [router, collectiveReadingHref]);
+
+  const handleOpenBookDetails = useCallback(() => {
+    bookDetailsModal.setIsOpen(true);
+  }, [bookDetailsModal.setIsOpen]);
+
+  const handleAuthorSearchFromDetails = useCallback(() => {
+    bookDetailsModal.setIsOpen(false);
+    handleNavigateToAuthor();
+  }, [bookDetailsModal.setIsOpen, handleNavigateToAuthor]);
+
+  const handleCollectiveReadingFromDetails = useCallback(() => {
+    bookDetailsModal.setIsOpen(false);
+    handleNavigateToCollectiveReading();
+  }, [bookDetailsModal.setIsOpen, handleNavigateToCollectiveReading]);
+
+  const handleScheduleFromDetails = useCallback(() => {
+    bookDetailsModal.setIsOpen(false);
+    handleNavigateToSchedule();
+  }, [bookDetailsModal.setIsOpen, handleNavigateToSchedule]);
+
+  const handleQuotesFromDetails = useCallback(() => {
+    bookDetailsModal.setIsOpen(false);
+    handleNavigateToQuotes();
+  }, [bookDetailsModal.setIsOpen, handleNavigateToQuotes]);
 
   const statusMap = {
     not_started: {
@@ -207,6 +236,12 @@ export function useBookCard({
     dialogEditModal,
     dialogDeleteModal,
     dialogAddShelfModal,
+    bookDetailsModal,
+    handleOpenBookDetails,
+    handleAuthorSearchFromDetails,
+    handleCollectiveReadingFromDetails,
+    handleScheduleFromDetails,
+    handleQuotesFromDetails,
     isLogged,
     dropdownTap,
     shareOnWhatsApp,
@@ -223,5 +258,6 @@ export function useBookCard({
     isFavoritePending,
     canAccessCollectiveReading,
     collectiveReadingHref,
+    handleNavigateToCollectiveReading,
   };
 }

--- a/src/services/books/books.mapper.ts
+++ b/src/services/books/books.mapper.ts
@@ -86,9 +86,10 @@ export class BookMapper {
     users: UserLookup[],
   ): string {
     if (!readerIds.length) return "";
-    const labels = readerIds.map(
-      (id) => users.find((u) => u.id === id)?.display_name ?? id,
-    );
+    const labels = readerIds
+      .map((id) => users.find((u) => u.id === id)?.display_name?.trim())
+      .filter((label): label is string => Boolean(label?.length));
+    if (!labels.length) return "";
     return formatList(labels);
   }
 }

--- a/src/services/books/tests/books.mapper.spec.ts
+++ b/src/services/books/tests/books.mapper.spec.ts
@@ -129,6 +129,34 @@ describe("BookMapper", () => {
     );
   });
 
+  it("enrichReadersDisplay não usa id como rótulo quando não há display_name", () => {
+    const book: BookDomain = {
+      id: "b1",
+      title: "T",
+      author: "A",
+      chosen_by: "u1",
+      pages: 1,
+      readerIds: ["11111111-1111-4111-8111-111111111111"],
+      readersDisplay: "x",
+      gender: null,
+      image_url: "/x.svg",
+      user_id: "u",
+      is_reread: false,
+      is_favorite: false,
+    };
+    expect(
+      BookMapper.enrichReadersDisplay(book, []).readersDisplay,
+    ).toBe("");
+    expect(
+      BookMapper.enrichReadersDisplay(book, [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          display_name: "Ana",
+        },
+      ]).readersDisplay,
+    ).toBe("Ana");
+  });
+
   it("enrichFavorite reflete ids no conjunto de favoritos", () => {
     const book: BookDomain = {
       id: "b1",


### PR DESCRIPTION
## Resumo

- Card principal abre modal com metadados completos do livro.
- Card exibe título, autor, linha de leitores (logado) e status.
- Modal: busca por autor, leitura coletiva, cronograma, citações (mesmas regras de desabilitar do menu ⋮).
- `BookMapper`: lista de leitores sem expor UUID quando não há `display_name`.

## Commit

`feat(book-card): add details modal and reader display`

## Summary by Sourcery

Add a book details modal to the book card, centralizing full metadata and related actions, while tightening how reader information is displayed.

New Features:
- Enable opening a detailed modal from the book card with full book metadata and contextual actions for schedule, quotes, collective reading, and author search.

Bug Fixes:
- Prevent reader UUIDs from being exposed in readersDisplay when no display_name is available, hiding readers info for unauthenticated users.

Enhancements:
- Refine the book card layout to make the main area open the details modal, while keeping favorite and overflow actions accessible without triggering navigation.

Tests:
- Expand book card and BookMapper tests to cover the details modal behavior, reader visibility rules, and updated mapping of reader display names.