### PR TITLE
feat(book-card): show author and pages on separate lines

### DIFF
--- a/src/components/bookCard/bookCard.tsx
+++ b/src/components/bookCard/bookCard.tsx
@@ -18,6 +18,7 @@ import { useBookCard } from "./hooks/useBookCard";
 import { BookCardProps } from "./types/bookCard.types";
 import { resolveBookCoverUrl } from "@/constants/bookCover";
 import { cn } from "@/lib/utils";
+import { formatBookPagesLabel } from "@/utils/formatters";
 
 export function BookCard(props: BookCardProps) {
   const { isShelf = false, hideInteractions = false } = props;
@@ -55,6 +56,8 @@ export function BookCard(props: BookCardProps) {
   const coverSizes = isShelf
     ? { width: 56, height: 92, className: "relative h-[92px] w-14 shrink-0 overflow-hidden rounded-md bg-muted/20 shadow-sm" }
     : { width: 90, height: 130, className: "relative h-[130px] w-[90px] shrink-0 overflow-hidden rounded-md shadow-sm" };
+
+  const pagesLabel = formatBookPagesLabel(book.pages);
 
   const bookMain = (
     <button
@@ -98,14 +101,31 @@ export function BookCard(props: BookCardProps) {
           </TooltipContent>
         </Tooltip>
 
-        <p
-          className={cn(
-            "truncate text-zinc-600 dark:text-zinc-400",
-            isShelf ? "text-[11px]" : "text-xs",
-          )}
-        >
-          {book.author}
-        </p>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <p
+              className={cn(
+                "min-w-0 text-zinc-600 dark:text-zinc-400",
+                isShelf ? "line-clamp-1 text-[11px]" : "line-clamp-2 text-xs leading-snug",
+              )}
+            >
+              {book.author}
+            </p>
+          </TooltipTrigger>
+          <TooltipContent sideOffset={4} className="max-w-xs text-pretty">
+            {book.author}
+          </TooltipContent>
+        </Tooltip>
+        {pagesLabel && (
+          <p
+            className={cn(
+              "shrink-0 tabular-nums text-zinc-500 dark:text-zinc-500",
+              isShelf ? "text-[10px] leading-tight" : "text-[11px] leading-tight",
+            )}
+          >
+            {pagesLabel}
+          </p>
+        )}
 
         {(showReadersOnCard || statusDisplay) && (
           <div

--- a/src/components/bookCard/components/bookCardDetailsModal/bookCardDetailsModal.tsx
+++ b/src/components/bookCard/components/bookCardDetailsModal/bookCardDetailsModal.tsx
@@ -23,6 +23,7 @@ import {
 import { getGenderLabel, getGenreBadgeColor } from "@/constants/genders";
 import { resolveBookCoverUrl } from "@/constants/bookCover";
 import { cn } from "@/lib/utils";
+import { formatBookPagesLabel } from "@/utils/formatters";
 
 import type { BookCardDetailsModalProps } from "./types/bookCardDetailsModal.types";
 
@@ -61,6 +62,8 @@ export default function BookCardDetailsModal({
 
   const showReaders = isLogged && Boolean(book.readersDisplay?.trim());
 
+  const pagesLabel = formatBookPagesLabel(book.pages);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
@@ -72,8 +75,17 @@ export default function BookCardDetailsModal({
             <DialogTitle className="text-balance pr-8 text-base leading-snug sm:text-lg">
               {book.title}
             </DialogTitle>
-            <DialogDescription className="text-left text-zinc-600 dark:text-zinc-400">
-              {book.author}
+            <DialogDescription asChild>
+              <div className="flex flex-col gap-0.5 text-left">
+                <span className="text-balance text-zinc-600 dark:text-zinc-400">
+                  {book.author}
+                </span>
+                {pagesLabel ? (
+                  <span className="text-sm tabular-nums text-zinc-500 dark:text-zinc-500">
+                    {pagesLabel}
+                  </span>
+                ) : null}
+              </div>
             </DialogDescription>
           </DialogHeader>
 

--- a/src/modules/bookUpsert/components/bookLookupPanel/index.tsx
+++ b/src/modules/bookUpsert/components/bookLookupPanel/index.tsx
@@ -4,6 +4,7 @@ import { memo } from "react";
 import { Loader2, Search, SearchX, BookOpen } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { formatBookPagesLabel } from "@/utils/formatters";
 import { BookLookupPanelProps } from "./bookLookupPanel.types";
 import { BookCandidate } from "../../types/bookCandidate.types";
 
@@ -81,7 +82,9 @@ const BookLookupPanel = memo(function BookLookupPanel({
 
       {!isSearching && candidates.length > 0 && (
         <div className="grid gap-2">
-          {candidates.map((candidate, index) => (
+          {candidates.map((candidate, index) => {
+            const pagesLine = formatBookPagesLabel(candidate.pages);
+            return (
             <button
               key={`${candidate.isbn ?? candidate.title}-${index}`}
               type="button"
@@ -106,17 +109,21 @@ const BookLookupPanel = memo(function BookLookupPanel({
                 <p className="text-sm font-medium leading-tight truncate">
                   {candidate.title}
                 </p>
-                <p className="text-xs text-muted-foreground truncate">
-                  {[candidate.author_name, candidate.pages ? `${candidate.pages} pág.` : null]
-                    .filter(Boolean)
-                    .join(" · ")}
+                <p className="text-xs text-muted-foreground line-clamp-2 leading-snug">
+                  {candidate.author_name}
                 </p>
+                {pagesLine ? (
+                  <p className="text-[11px] tabular-nums text-muted-foreground">
+                    {pagesLine}
+                  </p>
+                ) : null}
                 <span className="mt-1 inline-flex w-fit items-center rounded-sm bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
                   {SOURCE_LABEL[candidate.source]}
                 </span>
               </div>
             </button>
-          ))}
+          );
+          })}
         </div>
       )}
     </div>

--- a/src/utils/formatters/formatters.test.ts
+++ b/src/utils/formatters/formatters.test.ts
@@ -137,6 +137,20 @@ describe("formatters", () => {
     });
   });
 
+  describe("formatBookPagesLabel", () => {
+    it("returns suffix when pages present", async () => {
+      const { formatBookPagesLabel } = await import("./formatters");
+      expect(formatBookPagesLabel(256)).toBe("256 pág.");
+    });
+
+    it("returns null when pages missing or zero", async () => {
+      const { formatBookPagesLabel } = await import("./formatters");
+      expect(formatBookPagesLabel(undefined)).toBeNull();
+      expect(formatBookPagesLabel(null)).toBeNull();
+      expect(formatBookPagesLabel(0)).toBeNull();
+    });
+  });
+
   describe("formatYear", () => {
     it("returns null for undefined input", async () => {
       const { formatYear } = await import("./formatters");

--- a/src/utils/formatters/formatters.ts
+++ b/src/utils/formatters/formatters.ts
@@ -47,3 +47,7 @@ export function formatYear(year?: number | null) {
   if (!year) return null;
   return String(year);
 }
+
+export function formatBookPagesLabel(pages?: number | null): string | null {
+  return pages ? `${pages} pág.` : null;
+}


### PR DESCRIPTION
## Summary by Sourcery

Display book authors and page counts more clearly across book cards and related UI using a shared page-count formatter.

Enhancements:
- Show book authors with improved truncation and tooltip behavior in book cards and the details modal.
- Display book page counts on separate lines in book cards, lookup candidates, and the details modal using a shared formatter utility.
- Introduce a reusable formatter for rendering localized book page-count labels.

Tests:
- Add unit tests for the new book page-count formatter to cover presence and absence of page values.