### PR TITLE
Cursor/fix author autofill open modal when not found

### DIFF
--- a/src/app/api/book-lookup-v2/route.ts
+++ b/src/app/api/book-lookup-v2/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { BookLookupResponse } from "@/modules/bookUpsert/types/bookLookup.types";
+
+export const dynamic = "force-dynamic";
+
+const CACHE_TTL = 60 * 60;
+
+const DEFAULT_DEV_BOOK_PROVIDER =
+  "https://matheus98rocha-tbr-book-provider.hf.space";
+
+function resolveBookProviderBaseUrl(): string | undefined {
+  const raw = process.env.TBR_BOOK_PROVIDER_URL?.trim();
+  if (raw) return raw.replace(/\/+$/, "");
+  if (process.env.NODE_ENV === "development") return DEFAULT_DEV_BOOK_PROVIDER;
+  return undefined;
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const title = searchParams.get("title");
+  const isbn = searchParams.get("isbn");
+  const lang = searchParams.get("lang") ?? "por";
+
+  if ((!title && !isbn) || (title && isbn)) {
+    return NextResponse.json(
+      { error: "Informe title OU isbn (não ambos, não nenhum)." },
+      { status: 422 },
+    );
+  }
+
+  const baseUrl = resolveBookProviderBaseUrl();
+  if (!baseUrl) {
+    return NextResponse.json(
+      { error: "Serviço de busca indisponível." },
+      { status: 503 },
+    );
+  }
+
+  const params = new URLSearchParams();
+  if (title) params.set("title", title);
+  if (isbn) params.set("isbn", isbn);
+  params.set("lang", lang);
+
+  const fetchOptions =
+    process.env.NODE_ENV === "development"
+      ? ({ cache: "no-store" as const } satisfies RequestInit)
+      : ({ next: { revalidate: CACHE_TTL } } satisfies RequestInit);
+
+  try {
+    const upstreamRes = await fetch(
+      `${baseUrl}/books/lookup?${params.toString()}`,
+      { ...fetchOptions, signal: AbortSignal.timeout(25_000) },
+    );
+
+    if (!upstreamRes.ok) {
+      const bodyText = await upstreamRes.text().catch(() => "");
+      return NextResponse.json(
+        {
+          error: "Falha ao buscar livro.",
+          upstreamStatus: upstreamRes.status,
+          detail: bodyText.slice(0, 300),
+        },
+        {
+          status:
+            upstreamRes.status >= 400 && upstreamRes.status < 600
+              ? upstreamRes.status
+              : 502,
+        },
+      );
+    }
+
+    const data: BookLookupResponse = await upstreamRes.json();
+    return NextResponse.json(data);
+  } catch (e) {
+    console.error("book-lookup-v2 upstream fetch failed", {
+      params: params.toString(),
+      err: e,
+    });
+    return NextResponse.json(
+      { error: "Erro inesperado ao contatar o serviço de busca." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/modules/bookUpsert/bookUpsert.tsx
+++ b/src/modules/bookUpsert/bookUpsert.tsx
@@ -79,10 +79,9 @@ export function BookUpsert(props: CreateBookProps) {
     isLoadingUsers,
     chosenByOptions,
     bookData,
-    handleApplyCandidate,
-    lookupCandidates,
+    foundBook,
     isSearchingBooks,
-    hasSearchedBooks,
+    lookupError,
     lookupQuery,
     handleLookupQueryChange,
     handleSearchBooks,
@@ -157,13 +156,12 @@ export function BookUpsert(props: CreateBookProps) {
                           Busca automática
                         </p>
                         <BookLookupPanel
-                          candidates={lookupCandidates}
                           isSearching={isSearchingBooks}
-                          hasSearched={hasSearchedBooks}
+                          error={lookupError}
+                          foundBook={foundBook}
                           lookupQuery={lookupQuery}
                           onQueryChange={handleLookupQueryChange}
                           onSearch={handleSearchBooks}
-                          onSelect={handleApplyCandidate}
                         />
                       </section>
                       <Separator orientation="horizontal" />

--- a/src/modules/bookUpsert/components/bookLookupPanel/bookLookupPanel.types.ts
+++ b/src/modules/bookUpsert/components/bookLookupPanel/bookLookupPanel.types.ts
@@ -1,11 +1,10 @@
-import { BookCandidate } from "../../types/bookCandidate.types";
+import { BookLookupData } from "../../types/bookLookup.types";
 
 export interface BookLookupPanelProps {
-  candidates: BookCandidate[];
   isSearching: boolean;
-  hasSearched: boolean;
+  error: string | null;
+  foundBook: BookLookupData | null;
   lookupQuery: string;
   onQueryChange: (query: string) => void;
   onSearch: () => void;
-  onSelect: (candidate: BookCandidate) => void;
 }

--- a/src/modules/bookUpsert/components/bookLookupPanel/index.tsx
+++ b/src/modules/bookUpsert/components/bookLookupPanel/index.tsx
@@ -1,26 +1,20 @@
 "use client";
 
 import { memo } from "react";
-import { Loader2, Search, SearchX, BookOpen } from "lucide-react";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import { formatBookPagesLabel } from "@/utils/formatters";
-import { BookLookupPanelProps } from "./bookLookupPanel.types";
-import { BookCandidate } from "../../types/bookCandidate.types";
+import { BookOpen, CheckCircle2, Loader2, Search, SearchX } from "lucide-react";
 
-const SOURCE_LABEL: Record<BookCandidate["source"], string> = {
-  google_books: "Google Books",
-  open_library: "Open Library",
-};
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+import { BookLookupPanelProps } from "./bookLookupPanel.types";
 
 const BookLookupPanel = memo(function BookLookupPanel({
-  candidates,
   isSearching,
-  hasSearched,
+  error,
+  foundBook,
   lookupQuery,
   onQueryChange,
   onSearch,
-  onSelect,
 }: BookLookupPanelProps) {
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
@@ -73,57 +67,45 @@ const BookLookupPanel = memo(function BookLookupPanel({
         </div>
       )}
 
-      {!isSearching && hasSearched && candidates.length === 0 && (
+      {!isSearching && error && (
         <div className="flex flex-col items-center justify-center gap-2 py-6 text-muted-foreground">
           <SearchX className="size-8" />
-          <p className="text-sm">Nenhum resultado para &ldquo;{lookupQuery}&rdquo;</p>
+          <p className="text-sm">{error}</p>
         </div>
       )}
 
-      {!isSearching && candidates.length > 0 && (
-        <div className="grid gap-2">
-          {candidates.map((candidate, index) => {
-            const pagesLine = formatBookPagesLabel(candidate.pages);
-            return (
-            <button
-              key={`${candidate.isbn ?? candidate.title}-${index}`}
-              type="button"
-              onClick={() => onSelect(candidate)}
-              className="flex gap-3 rounded-lg border border-border p-2 text-left cursor-pointer transition-colors duration-150 hover:bg-muted/60 hover:border-violet-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring min-h-[44px] dark:hover:border-violet-800"
-            >
-              <div className="h-14 w-10 shrink-0 overflow-hidden rounded bg-muted">
-                {candidate.image_url ? (
-                  <img
-                    src={candidate.image_url}
-                    alt={`Capa de ${candidate.title}`}
-                    className="h-full w-full object-cover"
-                  />
-                ) : (
-                  <div className="flex h-full w-full items-center justify-center">
-                    <BookOpen className="size-4 text-muted-foreground" />
-                  </div>
-                )}
+      {!isSearching && foundBook && (
+        <div className="flex gap-3 rounded-lg border border-green-200 bg-green-50/50 p-2 dark:border-green-900 dark:bg-green-950/20">
+          <div className="h-14 w-10 shrink-0 overflow-hidden rounded bg-muted">
+            {foundBook.url_capa ? (
+              <img
+                src={foundBook.url_capa}
+                alt={`Capa de ${foundBook.nome_do_livro}`}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center">
+                <BookOpen className="size-4 text-muted-foreground" />
               </div>
+            )}
+          </div>
 
-              <div className="flex flex-1 flex-col justify-center gap-0.5 min-w-0">
-                <p className="text-sm font-medium leading-tight truncate">
-                  {candidate.title}
-                </p>
-                <p className="text-xs text-muted-foreground line-clamp-2 leading-snug">
-                  {candidate.author_name}
-                </p>
-                {pagesLine ? (
-                  <p className="text-[11px] tabular-nums text-muted-foreground">
-                    {pagesLine}
-                  </p>
-                ) : null}
-                <span className="mt-1 inline-flex w-fit items-center rounded-sm bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
-                  {SOURCE_LABEL[candidate.source]}
-                </span>
-              </div>
-            </button>
-          );
-          })}
+          <div className="flex flex-1 flex-col justify-center gap-0.5 min-w-0">
+            <div className="flex items-center gap-1.5">
+              <CheckCircle2 className="size-3.5 shrink-0 text-green-600 dark:text-green-500" />
+              <p className="text-xs font-medium text-green-700 dark:text-green-500">
+                Preenchido automaticamente
+              </p>
+            </div>
+            <p className="text-sm font-medium leading-tight truncate">
+              {foundBook.nome_do_livro}
+            </p>
+            {foundBook.autor && (
+              <p className="text-xs text-muted-foreground truncate">
+                {foundBook.autor}
+              </p>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/src/modules/bookUpsert/hooks/useBookLookupV2.ts
+++ b/src/modules/bookUpsert/hooks/useBookLookupV2.ts
@@ -1,0 +1,60 @@
+import { useCallback, useState } from "react";
+
+import type { BookLookupData } from "../types/bookLookup.types";
+
+type LookupParams =
+  | { type: "title"; value: string; lang?: string }
+  | { type: "isbn"; value: string };
+
+export function useBookLookupV2() {
+  const [book, setBook] = useState<BookLookupData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const lookup = useCallback(async (params: LookupParams) => {
+    setIsLoading(true);
+    setError(null);
+    setBook(null);
+
+    const searchParams = new URLSearchParams();
+    if (params.type === "title") {
+      searchParams.set("title", params.value);
+      if (params.lang) searchParams.set("lang", params.lang);
+    } else {
+      searchParams.set("isbn", params.value);
+    }
+
+    try {
+      const res = await fetch(
+        `/api/book-lookup-v2?${searchParams.toString()}`,
+      );
+
+      if (res.status === 404) {
+        setError("Nenhum livro encontrado.");
+        return;
+      }
+      if (res.status === 400) {
+        setError("ISBN inválido.");
+        return;
+      }
+      if (!res.ok) {
+        setError("Erro ao buscar livro. Tente novamente.");
+        return;
+      }
+
+      const data = await res.json();
+      setBook(data.book);
+    } catch {
+      setError("Erro de conexão.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const clear = useCallback(() => {
+    setBook(null);
+    setError(null);
+  }, []);
+
+  return { book, isLoading, error, lookup, clear };
+}

--- a/src/modules/bookUpsert/hooks/useBookUpsert.test.ts
+++ b/src/modules/bookUpsert/hooks/useBookUpsert.test.ts
@@ -1,20 +1,22 @@
-import { renderHook, act, waitFor } from "@testing-library/react";
-import { vi, Mock, beforeEach, describe, it, expect } from "vitest";
-import { useBookUpsert } from "./useBookUpsert";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { Mock, beforeEach, describe, expect, it, vi } from "vitest";
+
 import { useQuery } from "@tanstack/react-query";
 import { useIsLoggedIn } from "@/stores/hooks/useAuth";
 import { useUser } from "@/services/users/hooks/useUsers";
+
+import { BookLookupData } from "../types/bookLookup.types";
 import { useBookDialog } from "./useBookDialog";
-import { useBookLookup } from "./useBookLookup";
-import { usePlannedStartDateLabel } from "./usePlannedStartDateLabel";
+import { useBookLookupV2 } from "./useBookLookupV2";
+import { useBookUpsert } from "./useBookUpsert";
 import { usePlannedStartDateFieldVisibility } from "./usePlannedStartDateFieldVisibility";
-import { BookCandidate } from "../types/bookCandidate.types";
+import { usePlannedStartDateLabel } from "./usePlannedStartDateLabel";
 
 vi.mock("@tanstack/react-query", () => ({ useQuery: vi.fn() }));
 vi.mock("@/stores/hooks/useAuth", () => ({ useIsLoggedIn: vi.fn() }));
 vi.mock("@/services/users/hooks/useUsers", () => ({ useUser: vi.fn() }));
 vi.mock("./useBookDialog", () => ({ useBookDialog: vi.fn() }));
-vi.mock("./useBookLookup", () => ({ useBookLookup: vi.fn() }));
+vi.mock("./useBookLookupV2", () => ({ useBookLookupV2: vi.fn() }));
 vi.mock("./usePlannedStartDateLabel", () => ({
   usePlannedStartDateLabel: vi.fn(),
 }));
@@ -30,7 +32,7 @@ vi.mock("../../authors/services/authors.service", () => ({
 const mockSetValue = vi.fn();
 const mockReset = vi.fn();
 const mockSetSelected = vi.fn();
-const mockClearCandidates = vi.fn();
+const mockClearV2 = vi.fn();
 const mockSetIsBookFormOpen = vi.fn();
 
 const mockForm = {
@@ -71,14 +73,18 @@ const defaultDialogReturn = {
   handleChosenByChange: vi.fn(),
 };
 
-const defaultLookupReturn = {
-  candidates: [],
-  isSearching: false,
-  hasSearched: false,
-  lookupQuery: "",
-  handleLookupQueryChange: vi.fn(),
-  handleSearchBooks: vi.fn(),
-  clearCandidates: mockClearCandidates,
+const defaultLookupV2Return: {
+  book: BookLookupData | null;
+  isLoading: boolean;
+  error: string | null;
+  lookup: ReturnType<typeof vi.fn>;
+  clear: ReturnType<typeof vi.fn>;
+} = {
+  book: null,
+  isLoading: false,
+  error: null,
+  lookup: vi.fn(),
+  clear: mockClearV2,
 };
 
 const defaultProps = {
@@ -87,14 +93,23 @@ const defaultProps = {
   setIsBookFormOpen: mockSetIsBookFormOpen,
 };
 
-function setupMocks(overrides: {
-  authors?: { id: string; name: string }[];
-  isLoadingAuthors?: boolean;
-} = {}) {
+function setupMocks(
+  overrides: {
+    authors?: { id: string; name: string }[];
+    isLoadingAuthors?: boolean;
+    lookupV2?: Partial<typeof defaultLookupV2Return>;
+  } = {},
+) {
   (useIsLoggedIn as Mock).mockReturnValue(true);
-  (useUser as Mock).mockReturnValue({ chosenByOptions: [], isLoadingUsers: false });
+  (useUser as Mock).mockReturnValue({
+    chosenByOptions: [],
+    isLoadingUsers: false,
+  });
   (useBookDialog as Mock).mockReturnValue(defaultDialogReturn);
-  (useBookLookup as Mock).mockReturnValue(defaultLookupReturn);
+  (useBookLookupV2 as Mock).mockReturnValue({
+    ...defaultLookupV2Return,
+    ...overrides.lookupV2,
+  });
   (usePlannedStartDateLabel as Mock).mockReturnValue({
     plannedStartDateLabel: "",
   });
@@ -107,16 +122,17 @@ function setupMocks(overrides: {
   });
 }
 
-const makeCandidate = (partial: Partial<BookCandidate> = {}): BookCandidate => ({
-  title: "Dom Quixote",
-  author_name: "Miguel de Cervantes",
-  pages: 863,
-  image_url: null,
-  gender: "Fiction",
-  publisher: null,
-  published_date: null,
-  isbn: null,
-  source: "google_books",
+const makeBookLookupData = (
+  partial: Partial<BookLookupData> = {},
+): BookLookupData => ({
+  nome_do_livro: "Dom Quixote",
+  autor: "Miguel de Cervantes",
+  paginas: 863,
+  url_capa: null,
+  genero: "Fiction",
+  isbn_13: null,
+  isbn_10: null,
+  fonte: "google_books",
   ...partial,
 });
 
@@ -125,7 +141,7 @@ beforeEach(() => {
 });
 
 describe("useBookUpsert — handleDialogOpenChange", () => {
-  it("chama clearCandidates ao fechar o modal", () => {
+  it("chama clear ao fechar o modal", () => {
     setupMocks();
     const { result } = renderHook(() => useBookUpsert(defaultProps));
 
@@ -133,7 +149,7 @@ describe("useBookUpsert — handleDialogOpenChange", () => {
       result.current.handleDialogOpenChange(false);
     });
 
-    expect(mockClearCandidates).toHaveBeenCalledTimes(1);
+    expect(mockClearV2).toHaveBeenCalledTimes(1);
   });
 
   it("chama reset e setSelected('not_started') ao fechar o modal", () => {
@@ -148,7 +164,7 @@ describe("useBookUpsert — handleDialogOpenChange", () => {
     expect(mockSetSelected).toHaveBeenCalledWith("not_started");
   });
 
-  it("não chama clearCandidates ao abrir o modal", () => {
+  it("não chama clear ao abrir o modal", () => {
     setupMocks();
     const { result } = renderHook(() => useBookUpsert(defaultProps));
 
@@ -156,7 +172,7 @@ describe("useBookUpsert — handleDialogOpenChange", () => {
       result.current.handleDialogOpenChange(true);
     });
 
-    expect(mockClearCandidates).not.toHaveBeenCalled();
+    expect(mockClearV2).not.toHaveBeenCalled();
   });
 
   it("chama setIsBookFormOpen com o valor correto ao abrir e fechar", () => {
@@ -175,94 +191,97 @@ describe("useBookUpsert — handleDialogOpenChange", () => {
   });
 });
 
-describe("useBookUpsert — handleApplyCandidate", () => {
-  it("define o título do livro no formulário", () => {
-    setupMocks();
-    const { result } = renderHook(() => useBookUpsert(defaultProps));
-    const candidate = makeCandidate({ title: "Dom Quixote", author_name: null });
-
-    act(() => {
-      result.current.handleApplyCandidate(candidate);
+describe("useBookUpsert — efeito de foundBook", () => {
+  it("define o título do livro no formulário quando foundBook chega", async () => {
+    setupMocks({
+      lookupV2: { book: makeBookLookupData({ nome_do_livro: "Dom Quixote", autor: null }) },
     });
+    renderHook(() => useBookUpsert(defaultProps));
 
-    expect(mockSetValue).toHaveBeenCalledWith("title", "Dom Quixote");
+    await waitFor(() => {
+      expect(mockSetValue).toHaveBeenCalledWith("title", "Dom Quixote");
+    });
   });
 
-  it("define páginas, image_url e gender quando presentes", () => {
-    setupMocks();
-    const { result } = renderHook(() => useBookUpsert(defaultProps));
-    const candidate = makeCandidate({
-      pages: 500,
-      image_url: "https://img.com/cover.jpg",
-      gender: "Fiction",
+  it("define páginas, url_capa e genero quando presentes", async () => {
+    setupMocks({
+      lookupV2: {
+        book: makeBookLookupData({
+          paginas: 500,
+          url_capa: "https://img.com/cover.jpg",
+          genero: "Ficção",
+          autor: null,
+        }),
+      },
     });
+    renderHook(() => useBookUpsert(defaultProps));
 
-    act(() => {
-      result.current.handleApplyCandidate(candidate);
-    });
-
-    expect(mockSetValue).toHaveBeenCalledWith("pages", 500);
-    expect(mockSetValue).toHaveBeenCalledWith("image_url", "https://img.com/cover.jpg");
-    expect(mockSetValue).toHaveBeenCalledWith("gender", "Fiction");
-  });
-
-  it("chama clearCandidates após aplicar candidato", () => {
-    setupMocks();
-    const { result } = renderHook(() => useBookUpsert(defaultProps));
-
-    act(() => {
-      result.current.handleApplyCandidate(makeCandidate());
-    });
-
-    expect(mockClearCandidates).toHaveBeenCalledTimes(1);
-  });
-
-  it("não define author_id imediatamente ao aplicar candidato com autor", () => {
-    setupMocks({ authors: [] });
-    const { result } = renderHook(() => useBookUpsert(defaultProps));
-
-    act(() => {
-      result.current.handleApplyCandidate(makeCandidate({ author_name: "Cervantes" }));
-    });
-
-    expect(mockSetValue).not.toHaveBeenCalledWith("author_id", expect.anything());
-  });
-
-  it("expõe authorSearch com o nome do autor após aplicar candidato", () => {
-    setupMocks({ authors: [] });
-    const { result } = renderHook(() => useBookUpsert(defaultProps));
-
-    act(() => {
-      result.current.handleApplyCandidate(
-        makeCandidate({ author_name: "Miguel de Cervantes" }),
+    await waitFor(() => {
+      expect(mockSetValue).toHaveBeenCalledWith("pages", 500);
+      expect(mockSetValue).toHaveBeenCalledWith(
+        "image_url",
+        "https://img.com/cover.jpg",
       );
+      expect(mockSetValue).toHaveBeenCalledWith("gender", "Ficção");
     });
-
-    expect(result.current.authorSearch).toBe("Miguel de Cervantes");
   });
 
-  it("não altera authorSearch quando o candidato não tem autor", () => {
-    setupMocks();
+  it("não define author_id imediatamente quando foundBook tem autor", async () => {
+    setupMocks({
+      authors: [],
+      lookupV2: { book: makeBookLookupData({ autor: "Cervantes" }) },
+    });
+    renderHook(() => useBookUpsert(defaultProps));
+
+    await waitFor(() => {
+      expect(mockSetValue).toHaveBeenCalledWith("title", "Dom Quixote");
+    });
+    expect(mockSetValue).not.toHaveBeenCalledWith(
+      "author_id",
+      expect.anything(),
+    );
+  });
+
+  it("expõe authorSearch com o nome do autor após foundBook chegar", async () => {
+    setupMocks({
+      authors: [],
+      lookupV2: { book: makeBookLookupData({ autor: "Miguel de Cervantes" }) },
+    });
     const { result } = renderHook(() => useBookUpsert(defaultProps));
 
-    act(() => {
-      result.current.handleApplyCandidate(makeCandidate({ author_name: null }));
+    await waitFor(() => {
+      expect(result.current.authorSearch).toBe("Miguel de Cervantes");
     });
+  });
 
+  it("não altera authorSearch quando foundBook não tem autor", async () => {
+    setupMocks({
+      lookupV2: { book: makeBookLookupData({ autor: null }) },
+    });
+    const { result } = renderHook(() => useBookUpsert(defaultProps));
+
+    await waitFor(() => {
+      expect(mockSetValue).toHaveBeenCalledWith("title", "Dom Quixote");
+    });
     expect(result.current.authorSearch).toBe("");
+  });
+
+  it("não dispara efeito quando foundBook é null", () => {
+    setupMocks({ lookupV2: { book: null } });
+    renderHook(() => useBookUpsert(defaultProps));
+
+    expect(mockSetValue).not.toHaveBeenCalled();
   });
 });
 
 describe("useBookUpsert — auto-seleção de autor", () => {
-  it("define author_id quando autores carregam após candidato ser aplicado", async () => {
-    setupMocks({ authors: [], isLoadingAuthors: false });
-    const { result, rerender } = renderHook(() => useBookUpsert(defaultProps));
-
-    act(() => {
-      result.current.handleApplyCandidate(
-        makeCandidate({ author_name: "Miguel de Cervantes" }),
-      );
+  it("define author_id quando autores carregam após foundBook chegar", async () => {
+    setupMocks({
+      authors: [],
+      isLoadingAuthors: true,
+      lookupV2: { book: makeBookLookupData({ autor: "Miguel de Cervantes" }) },
     });
+    const { rerender } = renderHook(() => useBookUpsert(defaultProps));
 
     (useQuery as Mock).mockReturnValue({
       data: [{ id: "author-42", name: "Miguel de Cervantes" }],
@@ -277,14 +296,12 @@ describe("useBookUpsert — auto-seleção de autor", () => {
   });
 
   it("usa o primeiro autor disponível quando não há correspondência exata", async () => {
-    setupMocks({ authors: [], isLoadingAuthors: false });
-    const { result, rerender } = renderHook(() => useBookUpsert(defaultProps));
-
-    act(() => {
-      result.current.handleApplyCandidate(
-        makeCandidate({ author_name: "Nome Diferente" }),
-      );
+    setupMocks({
+      authors: [],
+      isLoadingAuthors: true,
+      lookupV2: { book: makeBookLookupData({ autor: "Nome Diferente" }) },
     });
+    const { rerender } = renderHook(() => useBookUpsert(defaultProps));
 
     (useQuery as Mock).mockReturnValue({
       data: [
@@ -301,15 +318,13 @@ describe("useBookUpsert — auto-seleção de autor", () => {
     });
   });
 
-  it("não define author_id enquanto autores ainda estão carregando", () => {
-    setupMocks({ authors: [], isLoadingAuthors: true });
-    const { result, rerender } = renderHook(() => useBookUpsert(defaultProps));
-
-    act(() => {
-      result.current.handleApplyCandidate(
-        makeCandidate({ author_name: "Cervantes" }),
-      );
+  it("não define author_id enquanto autores ainda estão carregando", async () => {
+    setupMocks({
+      authors: [],
+      isLoadingAuthors: true,
+      lookupV2: { book: makeBookLookupData({ autor: "Cervantes" }) },
     });
+    const { rerender } = renderHook(() => useBookUpsert(defaultProps));
 
     (useQuery as Mock).mockReturnValue({
       data: [{ id: "author-1", name: "Cervantes" }],
@@ -318,36 +333,37 @@ describe("useBookUpsert — auto-seleção de autor", () => {
 
     rerender();
 
-    expect(mockSetValue).not.toHaveBeenCalledWith("author_id", expect.anything());
+    expect(mockSetValue).not.toHaveBeenCalledWith(
+      "author_id",
+      expect.anything(),
+    );
   });
 
-  it("não define author_id quando authors está vazio após candidato aplicado", () => {
-    setupMocks({ authors: [], isLoadingAuthors: false });
+  it("abre o modal de criar autor quando autor não é encontrado no banco", async () => {
+    setupMocks({
+      authors: [],
+      isLoadingAuthors: true,
+      lookupV2: { book: makeBookLookupData({ autor: "Autor Desconhecido" }) },
+    });
     const { result, rerender } = renderHook(() => useBookUpsert(defaultProps));
 
-    act(() => {
-      result.current.handleApplyCandidate(
-        makeCandidate({ author_name: "Autor Desconhecido" }),
-      );
-    });
-
-    (useQuery as Mock).mockReturnValue({
-      data: [],
-      isLoading: false,
-    });
+    (useQuery as Mock).mockReturnValue({ data: [], isLoading: false });
 
     rerender();
 
+    await waitFor(() => {
+      expect(result.current.isAuthorModalOpen).toBe(true);
+    });
     expect(mockSetValue).not.toHaveBeenCalledWith("author_id", expect.anything());
   });
 
-  it("não auto-seleciona autor quando candidato não tem author_name", () => {
-    setupMocks({ authors: [], isLoadingAuthors: false });
-    const { result, rerender } = renderHook(() => useBookUpsert(defaultProps));
-
-    act(() => {
-      result.current.handleApplyCandidate(makeCandidate({ author_name: null }));
+  it("não auto-seleciona autor quando foundBook não tem autor", async () => {
+    setupMocks({
+      authors: [],
+      isLoadingAuthors: false,
+      lookupV2: { book: makeBookLookupData({ autor: null }) },
     });
+    const { rerender } = renderHook(() => useBookUpsert(defaultProps));
 
     (useQuery as Mock).mockReturnValue({
       data: [{ id: "author-1", name: "Qualquer Autor" }],
@@ -356,6 +372,9 @@ describe("useBookUpsert — auto-seleção de autor", () => {
 
     rerender();
 
-    expect(mockSetValue).not.toHaveBeenCalledWith("author_id", expect.anything());
+    expect(mockSetValue).not.toHaveBeenCalledWith(
+      "author_id",
+      expect.anything(),
+    );
   });
 });

--- a/src/modules/bookUpsert/hooks/useBookUpsert.ts
+++ b/src/modules/bookUpsert/hooks/useBookUpsert.ts
@@ -1,17 +1,24 @@
 import React, { useCallback, useDeferredValue, useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+
 import { useIsLoggedIn } from "@/stores/hooks/useAuth";
 import { useUser } from "@/services/users/hooks/useUsers";
-import { CreateBookProps } from "../bookUpsert.types";
-import { useBookDialog } from "./useBookDialog";
-import { useBookLookup } from "./useBookLookup";
-import { AuthorsService } from "../../authors/services/authors.service";
-import { ComboboxOption } from "../types/authorOptions";
-import { BookCandidate } from "../types/bookCandidate.types";
 import { BookCreateValidator } from "@/types/books.types";
 import { ControllerRenderProps } from "react-hook-form";
-import { usePlannedStartDateLabel } from "./usePlannedStartDateLabel";
+
+import { AuthorsService } from "../../authors/services/authors.service";
+import { CreateBookProps } from "../bookUpsert.types";
+import { ComboboxOption } from "../types/authorOptions";
+import { useBookDialog } from "./useBookDialog";
+import { useBookLookupV2 } from "./useBookLookupV2";
 import { usePlannedStartDateFieldVisibility } from "./usePlannedStartDateFieldVisibility";
+import { usePlannedStartDateLabel } from "./usePlannedStartDateLabel";
+
+function detectLookupType(query: string): "isbn" | "title" {
+  const digits = query.replace(/[\s\-]/g, "");
+  if (/^\d{10}$/.test(digits) || /^\d{13}$/.test(digits)) return "isbn";
+  return "title";
+}
 
 export function useBookUpsert({
   bookData,
@@ -56,15 +63,14 @@ export function useBookUpsert({
   });
 
   const {
-    candidates: lookupCandidates,
-    isSearching: isSearchingBooks,
-    hasSearched: hasSearchedBooks,
-    lookupQuery,
-    handleLookupQueryChange,
-    handleSearchBooks,
-    clearCandidates,
-  } = useBookLookup();
+    book: foundBook,
+    isLoading: isSearchingBooks,
+    error: lookupError,
+    lookup,
+    clear: clearBookLookup,
+  } = useBookLookupV2();
 
+  const [lookupQuery, setLookupQuery] = useState("");
   const [authorSearch, setAuthorSearch] = useState("");
   const [isAuthorModalOpen, setIsAuthorModalOpen] = useState(false);
   const [pendingAuthorLookup, setPendingAuthorLookup] = useState(false);
@@ -111,12 +117,13 @@ export function useBookUpsert({
         reset();
         setSelected("not_started");
         setAuthorSearch("");
-        clearCandidates();
+        setLookupQuery("");
+        clearBookLookup();
         setPendingAuthorLookup(false);
       }
       setIsBookFormOpen(open);
     },
-    [reset, setSelected, setIsBookFormOpen, clearCandidates],
+    [reset, setSelected, setIsBookFormOpen, clearBookLookup],
   );
 
   const handleCancelDiscoveryDialog = useCallback(() => {
@@ -157,8 +164,32 @@ export function useBookUpsert({
     setAuthorSearch(search);
   }, []);
 
+  const handleLookupQueryChange = useCallback(
+    (query: string) => {
+      setLookupQuery(query);
+      if (!query.trim()) clearBookLookup();
+    },
+    [clearBookLookup],
+  );
+
+  const handleSearchBooks = useCallback(() => {
+    const trimmed = lookupQuery.trim();
+    if (!trimmed) return;
+    const type = detectLookupType(trimmed);
+    lookup(
+      type === "isbn"
+        ? { type: "isbn", value: trimmed }
+        : { type: "title", value: trimmed },
+    );
+  }, [lookupQuery, lookup]);
+
   useEffect(() => {
-    if (!pendingAuthorLookup || isLoadingAuthors || authors.length === 0) return;
+    if (!pendingAuthorLookup || isLoadingAuthors || !deferredAuthorSearch) return;
+    if (authors.length === 0) {
+      setPendingAuthorLookup(false);
+      setIsAuthorModalOpen(true);
+      return;
+    }
     const match =
       authors.find(
         (a) => a.name.toLowerCase() === deferredAuthorSearch.toLowerCase(),
@@ -167,20 +198,17 @@ export function useBookUpsert({
     setPendingAuthorLookup(false);
   }, [pendingAuthorLookup, isLoadingAuthors, authors, deferredAuthorSearch, form]);
 
-  const handleApplyCandidate = useCallback(
-    (candidate: BookCandidate) => {
-      form.setValue("title", candidate.title);
-      if (candidate.pages) form.setValue("pages", candidate.pages);
-      if (candidate.image_url) form.setValue("image_url", candidate.image_url);
-      if (candidate.gender) form.setValue("gender", candidate.gender);
-      if (candidate.author_name) {
-        setAuthorSearch(candidate.author_name);
-        setPendingAuthorLookup(true);
-      }
-      clearCandidates();
-    },
-    [form, clearCandidates],
-  );
+  useEffect(() => {
+    if (!foundBook) return;
+    form.setValue("title", foundBook.nome_do_livro);
+    if (foundBook.paginas) form.setValue("pages", foundBook.paginas);
+    if (foundBook.url_capa) form.setValue("image_url", foundBook.url_capa);
+    if (foundBook.genero) form.setValue("gender", foundBook.genero);
+    if (foundBook.autor) {
+      setAuthorSearch(foundBook.autor);
+      setPendingAuthorLookup(true);
+    }
+  }, [foundBook, form]);
 
   const { plannedStartDateLabel } = usePlannedStartDateLabel(selected);
 
@@ -231,10 +259,9 @@ export function useBookUpsert({
     plannedStartDateLabel,
     shouldShowPlannedStartDate,
     bookData,
-    handleApplyCandidate,
-    lookupCandidates,
+    foundBook,
     isSearchingBooks,
-    hasSearchedBooks,
+    lookupError,
     lookupQuery,
     handleLookupQueryChange,
     handleSearchBooks,

--- a/src/modules/bookUpsert/types/bookLookup.types.ts
+++ b/src/modules/bookUpsert/types/bookLookup.types.ts
@@ -1,0 +1,16 @@
+export type BookLookupData = {
+  nome_do_livro: string;
+  url_capa: string | null;
+  autor: string | null;
+  genero: string | null;
+  paginas: number | null;
+  isbn_13: string | null;
+  isbn_10: string | null;
+  fonte: "open_library" | "google_books" | string;
+};
+
+export type BookLookupResponse = {
+  book: BookLookupData;
+  query: string;
+  source_count: number;
+};


### PR DESCRIPTION
## Summary by Sourcery

Integrate a new single-result book lookup flow into book upsert, auto-filling form fields from an external provider and improving author auto-selection and error handling.

New Features:
- Add a book lookup v2 API route backed by an external provider to fetch a single book by title or ISBN.
- Introduce a new useBookLookupV2 hook and BookLookupData types to encapsulate client-side lookup state and results.
- Auto-fill book form fields and trigger author auto-selection based on the found book data, including opening the create-author modal when no matching authors exist.

Enhancements:
- Refine the book lookup panel UI to show a single auto-filled result with status messaging and explicit error feedback instead of a list of selectable candidates.
- Update the book upsert hook to infer lookup type (ISBN vs title), manage lookup query state, and clear lookup state when the dialog closes.

Tests:
- Rewrite book upsert tests to cover the new foundBook-driven auto-fill flow, error-free dialog closing behavior, and the new author auto-selection and modal-opening logic.