### PR TITLE
feat(schedule): progresso de leitura no card e no cronograma

### DIFF
--- a/.sdd/specs/001-progresso-leitura-cronograma/checklists/requirements.md
+++ b/.sdd/specs/001-progresso-leitura-cronograma/checklists/requirements.md
@@ -1,0 +1,79 @@
+# Checklist — Requirements Review
+
+> Use este checklist antes de aprovar a `spec.md` e antes de avançar para a fase **Plan**.
+
+## A. Clareza WHAT/WHY
+
+- [ ] A spec descreve **somente** o WHAT e o WHY (sem stack, sem padrões de código, sem detalhes de API/SDK)?
+- [ ] Cada User Story tem prioridade explícita (P1/P2/P3)?
+- [ ] Cada User Story é **independentemente testável**?
+- [ ] Cada User Story tem ≥ 1 cenário no formato Given-When-Then?
+- [ ] O escopo (in/out) está explícito o suficiente para impedir scope creep?
+
+## B. Cobertura funcional
+
+- [ ] Todos os comportamentos descritos no WHY estão cobertos por pelo menos um FR?
+- [ ] Cobertura do happy path (usuário logado, livro `reading` com cronograma)?
+- [ ] Cobertura do caminho negativo principal: **sem cronograma** → ocultação silenciosa (FR-004)?
+- [ ] Cobertura do caminho negativo secundário: **status ≠ reading** → não exibir (FR-005)?
+- [ ] Cobertura de **visitante anônimo** (FR-008)?
+- [ ] Cobertura do contexto **estante** (FR-007) e da diferenciação imposta pela RN55?
+
+## C. Privacidade e isolamento
+
+- [ ] A regra de isolamento por `owner` (RN44) está reiterada e testável (User Story 3 / RNxx-04)?
+- [ ] Não há vazamento conceitual de progresso entre usuários em livros coletivos?
+
+## D. Estados de carregamento e erro
+
+- [ ] Comportamento durante loading inicial está descrito (FR-012)?
+- [ ] Comportamento em caso de erro de rede está descrito e é não bloqueante (FR-013)?
+- [ ] Comportamento otimista (toggle de leitura) está consistente entre superfícies (FR-010, FR-011)?
+
+## E. Acessibilidade e localização
+
+- [ ] A semântica do indicador é acessível a leitores de tela (FR-014)?
+- [ ] A informação não depende apenas de cor (FR-014)?
+- [ ] Todos os textos visíveis estão especificados em pt-BR (FR-009)?
+
+## F. Success Criteria mensuráveis
+
+- [ ] Cada SC é **mensurável** (sem adjetivos vagos como "rápido" ou "bonito")?
+- [ ] Há SC ligado a correção numérica (SC-003)?
+- [ ] Há SC ligado a performance/não regressão (SC-005)?
+- [ ] Há SC ligado a isolamento entre usuários (SC-006)?
+
+## G. Itens em aberto
+
+- [ ] Todos os `[NEEDS CLARIFICATION]` estão listados na seção 9 da spec?
+- [ ] Nenhum item em aberto bloqueia a fase Plan (apenas decisões técnicas a serem tomadas lá)?
+
+## H. Conformidade SDD
+
+- [ ] Numeração da pasta (`001-...`) está correta e única?
+- [ ] Pasta segue a convenção `.sdd/specs/NNN-<slug>/`?
+- [ ] Slug da feature é semântico e em kebab-case sem acentos (`progresso-leitura-cronograma` ✅)?
+- [ ] Nenhuma menção a stack tecnológica fora das seções de **dependências internas** (que são contextuais, não prescritivas)?
+
+## I. Próximos passos
+
+- [ ] Aprovar a spec (visto explícito do owner).
+- [ ] Resolver pendências bloqueantes (se surgirem).
+- [x] Avançar para a fase **Plan** (concluído em 2026-05-17 → ver `plan.md` / `data-model.md` / `contracts/`).
+
+---
+
+## J. Pós-Plan (Fase 2 entregue)
+
+- [ ] Revisar `plan.md` (decisões §2.1, §2.2, §2.3 que resolvem os `[NEEDS CLARIFICATION]` da spec).
+- [ ] Revisar `data-model.md` (zero alterações de schema; apenas RPC derivada).
+- [ ] Revisar `contracts/api-spec.md` (novo `GET /api/schedule/progress`).
+- [ ] Revisar `contracts/rpc-spec.sql` (RPC `get_schedule_progress_for_books`).
+- [ ] Confirmar índice `schedule(owner, book_id)` (criar via migration apenas se ausente — checar [[database/database-indexes-views]] no vault).
+- [ ] Avançar para Fase 3 (`tasks`) ou pausar para revisão arquitetural.
+
+---
+
+**Revisor:** _______________________
+**Data:** _______________________
+**Status:** [ ] Aprovado · [ ] Aprovado com ressalvas · [ ] Reprovado

--- a/.sdd/specs/001-progresso-leitura-cronograma/contracts/api-spec.md
+++ b/.sdd/specs/001-progresso-leitura-cronograma/contracts/api-spec.md
@@ -1,0 +1,138 @@
+# API Contract — Reading Progress
+
+**Feature ID:** 001
+**Endpoint introduzido:** `GET /api/schedule/progress`
+
+---
+
+## 1. `GET /api/schedule/progress`
+
+### 1.1 Propósito
+
+Retornar, para um conjunto de `bookIds` informados na query string, o agregado `(total, completed)` do cronograma do **usuário autenticado** (`auth.uid()`).
+
+### 1.2 Autenticação e autorização
+
+- **Sessão obrigatória** via `requireUser(supabase)` (mesmo padrão do POST/DELETE em `/api/schedule`).
+- **Anônimo:** rota responde `401 Unauthorized`.
+- **Autenticado mas sem cronograma para nenhum dos bookIds:** rota responde `200 OK` com array vazio. NÃO é erro.
+- **Backend honra RN44:** a RPC chamada internamente filtra `owner = auth.uid()`, então mesmo que o cliente envie `bookIds` de livros que ele não criou cronograma, a resposta omite essas entradas (alinhado à I-03 do `data-model.md`).
+
+### 1.3 Request
+
+**Método:** `GET`
+
+**Path:** `/api/schedule/progress`
+
+**Query params:**
+
+| Param      | Tipo                          | Obrigatório | Validação                                                                              |
+| ---------- | ----------------------------- | ----------- | -------------------------------------------------------------------------------------- |
+| `bookIds`  | CSV de UUIDs (`a,b,c,d,...`)  | Sim         | ≥ 1 UUID. Cada elemento deve ser UUID v4 válido. Limite máximo: **100 UUIDs por chamada** (proteção contra abuso). |
+
+**Exemplo:**
+
+```http
+GET /api/schedule/progress?bookIds=a1f2c3e4-1234-5678-9abc-def012345678,b2g3d4f5-2345-6789-abcd-ef0123456789
+Cookie: sb-access-token=...; sb-refresh-token=...
+```
+
+### 1.4 Response
+
+**Sucesso — `200 OK`**
+
+Content-Type: `application/json`
+
+```json
+[
+  {
+    "book_id": "a1f2c3e4-1234-5678-9abc-def012345678",
+    "total": 12,
+    "completed": 5
+  },
+  {
+    "book_id": "b2g3d4f5-2345-6789-abcd-ef0123456789",
+    "total": 8,
+    "completed": 8
+  }
+]
+```
+
+**Garantias do payload:**
+
+- Array de objetos (nunca `null`).
+- Ordem **não garantida** (cliente deve indexar por `book_id` — `Map<bookId, ProgressDomain>`).
+- Cada item satisfaz `0 <= completed <= total` e `total > 0` (I-02 / I-03).
+- Apenas livros que possuem cronograma do usuário aparecem (livros sem schedule são omitidos — alinhado a FR-004).
+- Headers: `Cache-Control: no-store` (alinhado ao padrão de outras rotas autenticadas como `GET /api/users`).
+
+### 1.5 Erros
+
+| Status | Cenário                                                                         | Body                                                                                                                |
+| ------ | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `400`  | `bookIds` ausente, vazio após `split(",")`, ou contém valor não-UUID.           | `{ "error": "Invalid bookIds", "details": { ... } }` (saída do `z.array(z.string().uuid())`)                        |
+| `400`  | `bookIds` excede 100 elementos.                                                 | `{ "error": "Too many bookIds (max 100)" }`                                                                         |
+| `401`  | Sessão ausente ou inválida.                                                     | `{ "error": "Unauthorized" }` (mesma forma de `requireUser`)                                                        |
+| `500`  | Falha na RPC ou conexão Supabase.                                               | `{ "error": "<message>" }` (mensagem do erro Postgres, alinhada ao padrão das outras rotas de `/api/schedule`)      |
+
+### 1.6 Estabilidade do contrato
+
+- **Adição compatível:** novos campos no objeto retornado (ex.: `percentage`, `last_completed_at`) podem ser adicionados sem versionar. Clientes ignoram campos desconhecidos.
+- **Remoção/renomeação:** quebra compatibilidade — exigirá nova versão da rota.
+
+---
+
+## 2. Validação Zod (referência)
+
+```text
+import { z } from "zod";
+
+const querySchema = z.object({
+  bookIds: z.string()
+    .min(1, "bookIds required")
+    .transform((s) => s.split(","))
+    .pipe(z.array(z.string().uuid()).min(1).max(100)),
+});
+```
+
+(implementação efetiva fica em `src/app/api/schedule/progress/route.ts` na fase Implement)
+
+---
+
+## 3. Fluxo server (referência)
+
+```
+1. const auth = await requireUser(supabase);
+   if (auth.errorResponse) return auth.errorResponse;
+2. parse query (querySchema) → bookIds: string[]
+3. const { data, error } = await supabase.rpc("get_schedule_progress_for_books", {
+     book_ids: bookIds,
+   });
+4. if (error) → 500
+5. return NextResponse.json(data ?? [], {
+     status: 200,
+     headers: { "Cache-Control": "no-store" },
+   });
+```
+
+---
+
+## 4. Compatibilidade
+
+- **Não substitui** nem altera `POST /api/schedule`, `DELETE /api/schedule`, nem `PATCH /api/schedule/[id]`.
+- **Não interage** com `/api/books`, `/api/users`, ou outras rotas. Acoplamento estritamente isolado.
+
+---
+
+## 5. Testes obrigatórios (referência)
+
+| Caso                                                                                 | Status esperado                                |
+| ------------------------------------------------------------------------------------ | ---------------------------------------------- |
+| Sem sessão.                                                                          | `401`                                          |
+| Sessão válida, `?bookIds=` ausente.                                                  | `400` "Invalid bookIds"                        |
+| Sessão válida, UUID malformado.                                                      | `400` "Invalid bookIds"                        |
+| Sessão válida, > 100 UUIDs.                                                          | `400` "Too many bookIds"                       |
+| Sessão válida, lista de UUIDs onde NENHUM tem cronograma.                            | `200`, body `[]`                               |
+| Sessão válida, lista mista (alguns têm cronograma, outros não).                      | `200`, body só com os que têm cronograma.      |
+| Sessão válida, lista contendo bookId de cronograma de OUTRO usuário (`userY`).       | `200`, body omite essa entrada (RN44 garantido pela RPC). |
+| Falha simulada no `supabase.rpc`.                                                    | `500` com mensagem do erro.                    |

--- a/.sdd/specs/001-progresso-leitura-cronograma/contracts/rpc-spec.sql
+++ b/.sdd/specs/001-progresso-leitura-cronograma/contracts/rpc-spec.sql
@@ -1,0 +1,90 @@
+-- =============================================================================
+-- RPC Contract — get_schedule_progress_for_books
+-- Feature: 001 — Progresso de leitura baseado no cronograma
+-- Status: Draft contract (referência para a migration final)
+-- =============================================================================
+--
+-- ESPECIFICAÇÃO
+-- -------------
+-- Devolve, para os book_ids informados, o agregado (total, completed) do
+-- cronograma do USUÁRIO AUTENTICADO (auth.uid()).
+--
+-- INVARIANTES
+-- -----------
+-- I-01  Apenas linhas com owner = auth.uid() são consideradas.
+-- I-02  0 <= completed <= total
+-- I-03  Apenas books com pelo menos 1 linha de schedule são retornados
+--       (HAVING COUNT(*) > 0 — livros sem cronograma somem da resposta).
+--
+-- SEGURANÇA
+-- ---------
+-- - SECURITY INVOKER: a função executa com as permissões do chamador, então a
+--   policy RLS de schedule (filtro owner = auth.uid() — RN44) é aplicada
+--   automaticamente. O WHERE explícito na query é defesa em profundidade.
+-- - GRANT EXECUTE apenas para `authenticated` (anon não pode chamar).
+-- - REVOKE ALL primeiro para garantir estado limpo (idempotência).
+--
+-- COMPATIBILIDADE
+-- ---------------
+-- Adicionar colunas à TABLE de retorno é permitido (clientes ignoram).
+-- Renomear/remover quebra contrato → exige nova função.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.get_schedule_progress_for_books(
+  book_ids uuid[]
+)
+RETURNS TABLE (
+  book_id   uuid,
+  total     bigint,
+  completed bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+  SELECT
+    s.book_id,
+    COUNT(*)::bigint                                AS total,
+    COUNT(*) FILTER (WHERE s.completed)::bigint     AS completed
+  FROM public.schedule s
+  WHERE s.owner   = auth.uid()
+    AND s.book_id = ANY(book_ids)
+  GROUP BY s.book_id
+  HAVING COUNT(*) > 0;
+$$;
+
+-- Permissões: somente usuários autenticados.
+REVOKE ALL ON FUNCTION public.get_schedule_progress_for_books(uuid[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_schedule_progress_for_books(uuid[]) TO authenticated;
+
+-- Índice de apoio (criar APENAS se não existir já em database-indexes-views.md).
+-- A query agrupa por book_id filtrando por owner — o índice composto cobre ambos.
+CREATE INDEX IF NOT EXISTS schedule_owner_book_id_idx
+  ON public.schedule (owner, book_id);
+
+-- =============================================================================
+-- Casos de teste manual (Supabase Studio / psql)
+-- =============================================================================
+--
+-- 1) Como usuário sem cronograma para nenhum book:
+--    SELECT * FROM public.get_schedule_progress_for_books(
+--      ARRAY['00000000-0000-0000-0000-000000000001']::uuid[]
+--    );
+--    Resultado esperado: 0 linhas.
+--
+-- 2) Como usuário com cronograma de 10 dias, 4 completos no bookA:
+--    SELECT * FROM public.get_schedule_progress_for_books(
+--      ARRAY[<bookA_id>]::uuid[]
+--    );
+--    Resultado esperado: (<bookA_id>, 10, 4).
+--
+-- 3) Como anon (sem JWT):
+--    SELECT * FROM public.get_schedule_progress_for_books(...);
+--    Resultado esperado: ERROR — permission denied for function (...).
+--
+-- 4) Defesa em profundidade — userX pedindo bookId de userY:
+--    Logado como userX, chamar a função com bookId cujo cronograma é de userY:
+--    Resultado esperado: 0 linhas (a função filtra por auth.uid()).
+--
+-- =============================================================================

--- a/.sdd/specs/001-progresso-leitura-cronograma/data-model.md
+++ b/.sdd/specs/001-progresso-leitura-cronograma/data-model.md
@@ -1,0 +1,177 @@
+# Data Model: Progresso de Leitura Baseado no Cronograma
+
+**Feature ID:** 001
+**Status:** Draft (acompanha `plan.md`)
+
+---
+
+## 1. Visão geral
+
+Esta feature **não introduz novas tabelas**, **não altera schema** e **não cria índices**. Toda a representação de progresso é **derivada em tempo de leitura** da tabela existente `public.schedule` (RN44), através de uma única **RPC Postgres** agregadora.
+
+```
+┌───────────────────────────────────┐         ┌────────────────────────────────────┐
+│  public.schedule (já existente)   │         │  RPC get_schedule_progress_for_books │
+│  ────────────────────────────     │ ──────► │  (book_ids uuid[]) RETURNS TABLE     │
+│  id, book_id, owner, date,        │         │    (book_id, total, completed)       │
+│  chapters, completed              │         │  SECURITY INVOKER + auth.uid()       │
+└───────────────────────────────────┘         └────────────────────────────────────┘
+                                                            │
+                                                            ▼
+                                              GET /api/schedule/progress?bookIds=...
+                                                            │
+                                                            ▼
+                                                ProgressPersistence[]
+                                                            │
+                                                ┌───────────┴───────────┐
+                                                ▼                       ▼
+                                  ProgressDomain (single)    ProgressByBookId (many)
+                                  (consumido pelo BookCard   (consumido pela Home
+                                   e tela /schedule)          via prefetch agregado)
+```
+
+---
+
+## 2. Entidades (camada lógica)
+
+### 2.1 `ProgressPersistence` (wire format / linha retornada pela RPC)
+
+| Campo       | Tipo     | Descrição                                                                 | Restrições                       |
+| ----------- | -------- | ------------------------------------------------------------------------- | -------------------------------- |
+| `book_id`   | `uuid`   | Identificador do livro no catálogo `books.id`                             | NOT NULL                         |
+| `total`     | `bigint` | Total de linhas em `schedule` para `(book_id, auth.uid())`                | `> 0` (linhas com total 0 são omitidas pela RPC) |
+| `completed` | `bigint` | Quantas dessas linhas têm `completed = true`                              | `0 <= completed <= total`        |
+
+**Observação:** o JSON serializado pela rota converte `bigint` para `number` (TanStack Query e React lidam como `number`). Tamanhos > 2^53 são inconcebíveis (cronogramas de leitura têm 10-200 linhas).
+
+### 2.2 `ProgressDomain` (domínio do client)
+
+| Campo        | Tipo     | Derivação                                                                           |
+| ------------ | -------- | ----------------------------------------------------------------------------------- |
+| `bookId`     | `string` | Cópia direta de `book_id` (camelCase).                                              |
+| `total`      | `number` | Cópia direta.                                                                       |
+| `completed`  | `number` | `Math.min(completed, total)` (clamp defensivo).                                     |
+| `percentage` | `number` | `Math.round((completed / total) * 100)`. Sempre inteiro 0-100.                      |
+
+Calculado por `computeReadingProgress(total, completed)`. Devolve `null` quando `total <= 0` (ocultação silenciosa — FR-004).
+
+### 2.3 `ProgressByBookId` (estrutura do cache "many")
+
+`Map<string /* bookId */, ProgressDomain>` — construído no client a partir de `ProgressPersistence[]`. Permite lookup O(1) pelos `BookCard` consumidores.
+
+---
+
+## 3. Relacionamentos
+
+| De                                       | Para                          | Cardinalidade | Observação                                                                  |
+| ---------------------------------------- | ----------------------------- | ------------- | --------------------------------------------------------------------------- |
+| `schedule.book_id`                       | `books.id`                    | N:1           | Já existente (FK em `schedule`).                                            |
+| `schedule.owner`                         | `users.id` (= `auth.uid()`)   | N:1           | Já existente (RN44).                                                        |
+| RPC `(book_ids)`                         | `schedule`                    | N:N (input)   | A RPC agrega linhas; relacionamento puramente computacional, sem persistência. |
+
+**Nenhuma nova FK, nenhum novo índice.** A consulta da RPC se beneficia do índice composto já existente em `schedule (book_id, owner)` (verificar em `database/database-indexes-views.md` no vault; se não existir, **considerar adicionar** — ver §6).
+
+---
+
+## 4. Invariantes de domínio
+
+- **I-01 (Isolamento por owner / RN44):** para qualquer chamada da RPC, todo `total` e `completed` retornado deve ser calculado APENAS sobre linhas onde `owner = auth.uid()`.
+- **I-02 (Subconjunto):** `0 <= completed <= total` para toda linha retornada.
+- **I-03 (Ausência implícita):** se um `book_id` solicitado não tem nenhuma linha em `schedule` para o `owner`, a RPC **omite** a entrada (não retorna `total=0`). O client interpreta ausência como "sem cronograma" → `null` → indicador oculto (FR-004).
+- **I-04 (Não-retroatividade):** alterar `schedule.completed` em uma linha afeta apenas o `completed` agregado; nunca o `total`. Apagar/criar linhas de cronograma (`/api/schedule` POST/DELETE existentes) afeta `total`.
+- **I-05 (Estabilidade da cache key):** a queryKey do TanStack Query para a versão "many" usa `bookIds` ordenados alfabeticamente (UUID lexicográfico) — alinhado a RN18.
+
+---
+
+## 5. Ciclo de vida dos dados
+
+| Evento                                                       | Efeito derivado                                                                                  |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| Usuário cria cronograma (`POST /api/schedule`)               | Próxima chamada da RPC para esse `bookId` passa a retornar `(total = N, completed = 0)`.         |
+| Usuário marca linha como lida (`PATCH /api/schedule/[id]`)   | `completed` aumenta em 1. Otimistic update no cache de `useSchedule` reflete na tela imediatamente; invalidação no `onSettled` repropaga ao cache `many` da Home. |
+| Usuário desmarca linha                                       | `completed` diminui em 1; mesmo fluxo.                                                           |
+| Usuário apaga cronograma (`DELETE /api/schedule?bookId=`)    | RPC para de retornar entrada para esse `bookId` → indicador some.                                |
+| Usuário muda `status` do livro de `reading` para `paused`    | Sem efeito no dado; o filtro de exibição (FR-005) é apenas no client (`BookCard` deixa de renderizar). |
+
+---
+
+## 6. Performance e índices
+
+### 6.1 Plano de query da RPC
+
+A query base é:
+
+```text
+SELECT
+  s.book_id,
+  COUNT(*)              AS total,
+  COUNT(*) FILTER (WHERE s.completed) AS completed
+FROM public.schedule s
+WHERE s.owner   = auth.uid()
+  AND s.book_id = ANY(book_ids)
+GROUP BY s.book_id
+HAVING COUNT(*) > 0;
+```
+
+### 6.2 Índices
+
+- **Recomendado verificar:** índice composto `schedule(owner, book_id)` (ou `schedule(book_id, owner)`). Se ausente, criar na mesma migration:
+  ```sql
+  CREATE INDEX IF NOT EXISTS schedule_owner_book_id_idx
+    ON public.schedule (owner, book_id);
+  ```
+- **Justificativa:** a Home dispara a RPC com 1-8 `book_ids`. Sem índice, scan sequencial degrada com cronogramas longos × muitos usuários.
+- **Ação obrigatória no Plan/Tasks:** consultar `database/database-indexes-views.md` no vault para confirmar se o índice já existe; se sim, omitir a criação. Marcar como [DECISÃO_PENDENTE_NA_TASK].
+
+### 6.3 Tamanho do payload
+
+Estimativa por chamada do endpoint:
+- `8 bookIds × ~50 bytes JSON cada = ~400 bytes`.
+- Negligível comparado ao payload da lista de livros (`bookService.getAll` retorna ~3-10KB por página).
+
+### 6.4 Caching
+
+- TanStack Query com `staleTime = 5min` (RN19) reduz drasticamente fetches em navegação repetida.
+- Invalidação ativa pós-toggle propaga atualizações sem polling.
+
+---
+
+## 7. Segurança (RLS / RBAC)
+
+| Camada              | Mecanismo                                                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **Postgres (RLS)**  | A RPC é `SECURITY INVOKER` → herda automaticamente a policy de `schedule` que filtra `owner = auth.uid()` (RN44).            |
+| **Defesa em profundidade** | Mesmo se a policy mudar, a RPC já contém `WHERE s.owner = auth.uid()` na própria query.                                |
+| **Anon**            | `GRANT EXECUTE` apenas para `authenticated`. Anônimo recebe `42501 permission denied` (refletido como `403` ou `401` pela rota). |
+| **API Route**       | `requireUser` valida sessão antes de chamar a RPC. Sem sessão → `401` (RN20).                                                |
+| **Vault**           | Promover a RNxx-04 (já na spec, será confirmada após entrega) e linkar com [[database/database-rls-policies]] e [[business-rules#RN44]]. |
+
+---
+
+## 8. Conformidade com domínios existentes
+
+| Domínio existente                          | Como esta feature se encaixa                                                                                                  |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| `public.schedule` + RN44                   | Único reader. Nenhuma escrita nova. Nenhum trigger novo.                                                                      |
+| `public.books` + `status`                  | O escopo `status = reading` é aplicado **somente no client** (FR-005). A RPC não consulta `books` (princípio: cada RPC faz uma coisa). |
+| `get_reading_leaderboard` (RN10 — derivativa) | Precedente arquitetural: função SQL `STABLE` agregando de `readers[]` e `end_date`. Esta feature segue o mesmo padrão.    |
+| Modelo de leitura coletiva (RN42 / RN59)   | Indiferente — cada `schedule.owner` é único por usuário. Leitura coletiva mantém um cronograma por participante.              |
+
+---
+
+## 9. Considerações de evolução futura (não escopo do MVP)
+
+1. **Ponderação por capítulos** (descartada em §2.1 do Plan) — exigiria parser de `chapters` string. Caso adotada, alterar a RPC para devolver também `chapters_total` e `chapters_completed`, manter retrocompatibilidade adicionando colunas (não removendo).
+2. **Histórico de progresso (tracking temporal)** — exigiria nova tabela. Fora deste escopo.
+3. **Progresso em estantes (`isShelf=true`)** — UI-only; nenhum impacto no modelo de dados.
+4. **Atrasos / pendências** — derivável adicionando `expected_completed_through_today` na RPC com base em `WHERE date <= CURRENT_DATE`. Extensão futura sem schema novo.
+
+---
+
+## 10. Resumo executivo
+
+- **Zero novas tabelas, zero alterações de schema.**
+- **1 nova RPC Postgres `STABLE` + `SECURITY INVOKER` + filtro `auth.uid()`.**
+- **Possível 1 novo índice composto** em `schedule(owner, book_id)` (apenas se ausente — verificar vault).
+- **2 novos tipos no client** (`ProgressPersistence` wire / `ProgressDomain` puro).
+- **Nenhuma quebra de contrato** com endpoints, hooks ou componentes existentes.

--- a/.sdd/specs/001-progresso-leitura-cronograma/plan.md
+++ b/.sdd/specs/001-progresso-leitura-cronograma/plan.md
@@ -1,0 +1,447 @@
+# Implementation Plan: Progresso de Leitura Baseado no Cronograma
+
+**Feature ID:** 001
+**Spec:** [spec.md](./spec.md)
+**Status:** Draft (pós-aprovação da Spec)
+**Criada em:** 2026-05-17
+
+---
+
+## 1. Summary
+
+A spec define um indicador visual de progresso derivado **exclusivamente** do cronograma do usuário atual (`schedule.owner = auth.uid()`), exibido em duas superfícies (`BookCard` na Home e topo da tela `/schedule/[id]/[title]`), restrito a livros com `status = reading`, com **ocultação silenciosa** quando o cronograma não existe.
+
+Este plano consolida as 3 decisões técnicas em aberto na seção 9 da spec e desenha a arquitetura completa em conformidade com os padrões do repositório (**Hook-First**, separação Service/Mapper/Hook/UI, TanStack Query com `staleTime` consistente — RN19, RLS via RPC respeitando `auth.uid()` — RN44/RN48, pt-BR — diretriz global).
+
+A abordagem evita N requisições por card na Home através de **uma única RPC agregada** consumida em lote a partir da lista de livros já carregada pelo `useHome`. Na tela de Cronograma, o progresso é **derivado em memória** do array que `useSchedule` já fornece, garantindo sincronia 100% otimista com o toggle de leitura existente.
+
+---
+
+## 2. Decisões técnicas (resolução dos `[NEEDS CLARIFICATION]` da spec)
+
+### 2.1 Unidade do cálculo (resposta a `[NEEDS CLARIFICATION] #1`)
+
+**Decisão:** **1 linha de cronograma = 1 unidade**.
+
+- **Por quê:**
+  - O `generateBookSchedule` já balanceia capítulos por dia via `chaptersPerDay` (default 3). Em ~95% dos casos as linhas têm peso equivalente.
+  - O campo `schedule.chapters` é uma **string livre** (`"1-3"`, `"Prólogo, 1"`, `"11"`, `"Epílogo"`) — ponderar exigiria um parser robusto, novo conjunto de testes e tratamento de edge cases (faixas com hífen, prólogos sem número, epílogos).
+  - Semanticamente a tabela representa "dias de leitura": "X dias lidos de Y dias planejados" é mais natural na UI ("Você está no 4º dia de 10").
+- **Trade-off aceito:** dias muito diferentes em volume de capítulos (raros, criados manualmente fora do gerador) representarão progresso "achatado". Aceitável no MVP; pode ser extendido posteriormente com ponderação.
+- **Impacto na spec:** atualizar **RNxx-03** como decisão definitiva (não mais com `[NEEDS CLARIFICATION]`).
+
+### 2.2 Estratégia de fetch na Home (resposta a `[NEEDS CLARIFICATION] #2` / R-01)
+
+**Decisão:** **RPC agregada Postgres** + **prefetch único em lote** no `useHome`.
+
+- **Arquitetura:**
+  - Nova RPC `public.get_schedule_progress_for_books(book_ids uuid[])` executa em `SECURITY INVOKER` e usa `auth.uid()` internamente como filtro, retornando `{ book_id, total, completed }` apenas para os livros recebidos. **Naturalmente** alinhada à RN44 (a RPC nunca devolve progresso de outro usuário; é o próprio RLS implícito de `auth.uid()`).
+  - Nova rota `GET /api/schedule/progress?bookIds=a,b,c` (autenticada via `requireUser`) chama a RPC e devolve `[{ book_id, total, completed }]`.
+  - Novo hook `useReadingProgressMany(bookIds)` consome a rota via TanStack Query.
+  - `useHome` (ou um wrapper intermediário) dispara o hook **uma vez** passando os `bookIds` da página corrente filtrados por `status === "reading"`. O `BookCard` na Home consulta o cache via `useReadingProgress(bookId)` (que faz `useQuery` na mesma key OU usa `useQueries`/`useSelector` para pegar a fatia do cache agregado).
+- **Por quê não opção B (fetch por card):**
+  - 8 cards × 1 request = pico de 8 requests redundantes ao montar a Home (ou pior se o usuário pagina).
+  - Acopla o `BookCard` ao endpoint do schedule, dificultando manter o card como componente puro reutilizável.
+- **Por quê não opção C apenas (prefetch em lote sem endpoint agregado):**
+  - Disparar `useSchedule` por livro internamente carrega TODAS as linhas (potencialmente 30-100 linhas × N livros). A RPC agregada devolve só `(total, completed)` — payload mínimo.
+- **Mitigação de R-01:** o endpoint agregado é a contra-medida explícita.
+
+### 2.3 Invalidação cross-screen (resposta a `[NEEDS CLARIFICATION] #3` / R-02)
+
+**Decisão:** **Aproveitar a invalidação por prefixo já existente** + **predicate para o cache agregado**.
+
+- Já temos `getScheduleBookQueryFilterKey(bookId) = ["schedule", bookId]` invalidada em `onSettled` do `useOptimisticScheduleReadToggle`.
+- A nova versão **single** usará a key `["schedule", bookId, "progress", userId]` — **invalida automaticamente** com a regra atual (sem mudar uma linha do toggle).
+- A nova versão **many** usará a key `["schedule", "progress", "many", sortedHash, userId]` — **NÃO** é tocada pelo invalidate atual. Solução: adicionar uma segunda chamada de `invalidateQueries` com `predicate` no `onSettled` (alteração cirúrgica de 3 linhas no hook existente, ou criação de utilitário `invalidateAllReadingProgressCaches`).
+- **Na tela `/schedule`:** o progresso será **derivado em memória** do array que `useSchedule` retorna (NÃO via `useReadingProgress`). Sincronia otimista é 100% nativa do React, sem refetch.
+- **Mitigação de R-02:** comportamento garantido pelo `staleTime` consistente já em uso (RN19) + invalidação ativa.
+
+---
+
+## 3. Technical Context
+
+| Item                          | Decisão                                                                                                |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Linguagem**                 | TypeScript estrito (já consolidado)                                                                    |
+| **Framework**                 | Next.js 15 (App Router)                                                                                |
+| **UI Runtime**                | React 19 + RSC + Client components onde necessário                                                     |
+| **Estado servidor**           | TanStack Query v5 (já consolidado)                                                                     |
+| **Estado client global**      | Zustand stores existentes (`useUserStore`)                                                             |
+| **Estilo / Tokens**           | Tailwind + componentes shadcn já em `src/components/ui` (incluindo `<Progress />` em `progress.tsx`)   |
+| **Persistência**              | Supabase Postgres — **nenhuma nova tabela**. Apenas uma **RPC** derivada (`SECURITY INVOKER`)          |
+| **Auth/RLS**                  | RN44 já garante isolamento por `owner`. RPC roda como invoker → herda RLS automaticamente               |
+| **API**                       | Next App Router (`src/app/api/schedule/progress/route.ts`)                                             |
+| **Testes**                    | Vitest + Testing Library (padrão do repo). Cobrir hooks, service, RPC integrada via rota               |
+| **Localização**               | pt-BR em todos os textos (FR-009)                                                                      |
+| **Acessibilidade**            | Componente `<Progress />` shadcn + label textual associado (FR-014)                                    |
+
+---
+
+## 4. Project Structure (novos arquivos + deltas)
+
+### 4.1 Novos arquivos
+
+```text
+src/modules/schedule/
+├── services/
+│   ├── readingProgress.service.ts             # GET /api/schedule/progress?bookIds=...
+│   └── readingProgress.service.test.ts
+├── hooks/
+│   ├── useReadingProgress.ts                  # Single — usado pelo BookCard
+│   ├── useReadingProgress.spec.ts
+│   ├── useReadingProgressMany.ts              # Lote — usado pelo useHome para prefetch agregado
+│   └── useReadingProgressMany.spec.ts
+├── utils/
+│   ├── computeReadingProgress.ts              # função pura: (total, completed) → ProgressDomain
+│   ├── computeReadingProgress.test.ts
+│   ├── readingProgressQueryKey.ts             # query keys (single + many)
+│   └── readingProgressQueryKey.test.ts
+├── types/
+│   └── readingProgress.types.ts               # ProgressDomain / ProgressPersistence / ProgressInputMany
+└── components/
+    └── readingProgressIndicator/
+        ├── readingProgressIndicator.tsx       # componente visual (puramente apresentacional)
+        ├── readingProgressIndicator.test.tsx
+        ├── types/readingProgressIndicator.types.ts
+        └── index.ts
+
+src/app/api/schedule/progress/
+├── route.ts                                   # GET aggregated
+└── route.test.ts
+
+supabase/migrations/
+└── 20260517120000_schedule_progress_rpc.sql   # RPC + GRANTs
+```
+
+### 4.2 Arquivos alterados (deltas mínimos)
+
+```text
+src/components/bookCard/bookCard.tsx
+  - Renderizar <ReadingProgressIndicator bookId variant="card" /> condicional a:
+      isLogged && !isShelf && book.status === "reading"
+  - Posição: dentro do bloco "mt-auto" abaixo do statusDisplay (não afeta layout em estantes).
+
+src/components/bookCard/hooks/useBookCard.ts
+  - Exportar derivado boolean shouldShowProgress = isLogged && !isShelf && book.status === "reading"
+    (mantém o componente burro; lógica fica no hook — diretriz Hook-First).
+
+src/modules/schedule/index.tsx
+  - Renderizar <ReadingProgressIndicator bookId={id} variant="page" /> abaixo do <header> e acima de
+    {shouldDisplayScheduleTable ? ... : ...}.
+  - Usa internamente um hook variante (ver §5.3) que deriva do schedule já carregado, sem novo fetch.
+
+src/modules/schedule/hooks/useOptimisticScheduleReadToggle.ts
+  - No onSettled: adicionar invalidação adicional para a key "many"
+    (ver §5.5 — alternativa: utilitário invalidateAllReadingProgressCaches).
+
+src/modules/schedule/hooks/index.ts
+  - Exportar useReadingProgress, useReadingProgressMany.
+
+src/modules/schedule/services/index.ts (criar se ainda não exporta o service novo)
+
+src/modules/home/hooks/useHome.ts (OU novo wrapper)
+  - Após booksQueryData resolver, chamar useReadingProgressMany com os bookIds em status "reading".
+  - Decisão: criar hook auxiliar useHomeReadingProgressPrefetch para preservar a complexidade atual
+    do useHome (já com 700+ linhas). Ver §5.4.
+```
+
+---
+
+## 5. Detalhamento de implementação
+
+### 5.1 RPC Postgres (migration)
+
+Arquivo: `supabase/migrations/20260517120000_schedule_progress_rpc.sql`
+
+Responsabilidade: agregar `total` e `completed` por `book_id` para o usuário atual, restrito aos `book_ids` recebidos.
+
+Características obrigatórias:
+- `LANGUAGE sql STABLE` (sem efeitos colaterais, lógica determinística).
+- `SECURITY INVOKER` (default) — RLS é respeitado automaticamente; a função só vê linhas do próprio usuário via policy de `schedule` (RN44).
+- Internamente filtra com `owner = auth.uid()` como **defesa em profundidade** (mesmo se a policy for relaxada no futuro).
+- `GRANT EXECUTE ... TO authenticated;` (anon não pode chamar).
+- Retorna apenas linhas onde `total > 0` (livros sem schedule são omitidos no retorno; alinhado a FR-004).
+
+Contrato detalhado em `contracts/rpc-spec.sql`.
+
+### 5.2 Service `ReadingProgressService`
+
+Responsabilidade: apenas falar HTTP com `GET /api/schedule/progress`. Sem lógica de cálculo (essa fica em `computeReadingProgress.ts`).
+
+Padrão idêntico ao `ScheduleUpsertService` (try/catch + `ErrorHandler.normalize` + `apiJson`). Métodos:
+
+```text
+getMany(bookIds: string[]): Promise<ProgressPersistence[]>
+```
+
+- Curto-circuita devolvendo `[]` se `bookIds.length === 0` (não dispara HTTP — economia da camada Service).
+- Concatena bookIds em `?bookIds=a,b,c` (parsed server-side com `z.string().uuid().array()`).
+
+### 5.3 Hooks
+
+#### `useReadingProgress(bookId, options?)`
+
+- Usado pelo `BookCard`.
+- Internamente apenas **lê o cache populado** pela versão `many` (via `queryClient.getQueryData` + `useQuery` com `enabled: false` e `placeholderData` derivando do many). 
+- **Decisão de fallback:** se o cache `many` ainda não tiver resposta para esse `bookId`, o hook devolve `null` (não dispara fetch single). Isso garante 1 single source of truth (a chamada batch) e evita race conditions.
+- **Exceção:** se o consumidor explicitamente passar `options.fallbackToSingle = true` (não usado na Home, mas disponível para usos futuros), o hook dispara `useQuery` no endpoint single — **MAS** esse modo NÃO é parte do MVP. Marcar como "extensão futura" no JSDoc.
+- Retorna `{ progress: ProgressDomain | null, isLoading: boolean }`.
+
+#### `useReadingProgressMany(bookIds)`
+
+- Usado pelo `useHomeReadingProgressPrefetch` (e potencialmente outras telas no futuro).
+- TanStack Query:
+  - `queryKey: readingProgressManyQueryKey(bookIds, userId)` — id list ordenado para cache estável (RN18).
+  - `queryFn: () => readingProgressService.getMany(bookIds)`.
+  - `enabled: isLoggedIn && bookIds.length > 0`.
+  - `staleTime: 1000 * 60 * 5` (alinhado a RN19).
+  - `gcTime: 1000 * 60 * 10`.
+- Retorna `{ progressByBookId: Map<bookId, ProgressDomain>, isLoading, isError }`.
+
+#### `useScheduleReadingProgress(bookId)` (interno à tela de cronograma)
+
+- **NÃO** faz fetch. É um wrapper que consome o array já carregado por `useSchedule(bookId)` e aplica `computeReadingProgress` em memória.
+- Garante sincronia 100% otimista com o toggle existente (FR-010, SC-004).
+- Reutilizado pelo `<ReadingProgressIndicator variant="page" />` exclusivamente.
+
+### 5.4 Prefetch agregado na Home
+
+Decisão: **criar hook auxiliar** `useHomeReadingProgressPrefetch(allBooks)` em vez de incharcar mais `useHome`. Razão: `useHome` já tem 747 linhas e múltiplos `useMemo`/`useEffect` — adicionar lógica de progresso lá viola o princípio de coesão.
+
+Localização: `src/modules/home/hooks/useHomeReadingProgressPrefetch.ts`.
+
+Comportamento:
+1. Extrai `bookIds` dos livros em `status === "reading"` da página corrente.
+2. Chama `useReadingProgressMany(bookIds)` (TanStack Query cuida da deduplicação).
+3. Não retorna nada (efeito colateral é popular o cache).
+
+Integração no `useHome.ts`: 1 linha de chamada após `allBooks` resolver:
+
+```typescript
+useHomeReadingProgressPrefetch(allBooks?.data ?? []);
+```
+
+### 5.5 Invalidação para a key "many"
+
+Opção escolhida: criar utilitário em `src/modules/schedule/utils/readingProgressQueryKey.ts`:
+
+```typescript
+export async function invalidateReadingProgressManyCaches(queryClient: QueryClient) {
+  await queryClient.invalidateQueries({
+    predicate: (query) =>
+      Array.isArray(query.queryKey) &&
+      query.queryKey[0] === "schedule" &&
+      query.queryKey[1] === "progress" &&
+      query.queryKey[2] === "many",
+  });
+}
+```
+
+Chamado no `onSettled` do `useOptimisticScheduleReadToggle`:
+
+```typescript
+onSettled: async () => {
+  await queryClient.invalidateQueries({
+    queryKey: getScheduleBookQueryFilterKey(bookId),
+  });
+  await invalidateReadingProgressManyCaches(queryClient);
+},
+```
+
+Delta: ~5 linhas no hook existente. Coberto por teste de integração já existente para o toggle (extender o spec).
+
+### 5.6 Componente `<ReadingProgressIndicator />`
+
+Puramente apresentacional (UI). Aceita props:
+
+```text
+{
+  bookId: string;
+  variant: "card" | "page";
+  progress: ProgressDomain | null;     // injetado pelo hook via prop drilling controlado
+  isLoading: boolean;
+}
+```
+
+Comportamento (alinhado a FR-004 / FR-005 / FR-013):
+- Se `!progress` → retorna `null` (ocultação silenciosa).
+- Se `isLoading && !progress` → retorna `null` (não exibe estado intermediário no `card`, evita layout shift). Para `variant="page"` na tela de cronograma, isLoading raramente acontece pois o dado vem do `useSchedule` já carregado.
+- Caso contrário, renderiza:
+  - `variant="card"`: barra compacta + texto `"X de Y"` em tabular-nums (estilo consistente com `pagesLabel` já existente).
+  - `variant="page"`: barra larga + texto `"X de Y dias lidos (Z%)"` (% arredondado para inteiro).
+- Acessibilidade (FR-014): `role="progressbar"` com `aria-valuenow / aria-valuemin / aria-valuemax`, `aria-label` em pt-BR descritivo.
+
+Hook adapter para o card: o `<ReadingProgressIndicator />` exposto a partir do módulo schedule terá uma variante "self-fetching" exportada como `<CardReadingProgressIndicator bookId />` (compositional helper) que internamente usa `useReadingProgress(bookId)` e injeta props no apresentacional. Isso mantém o `BookCard` totalmente declarativo (`<CardReadingProgressIndicator bookId={book.id} />`).
+
+### 5.7 Função pura `computeReadingProgress`
+
+`src/modules/schedule/utils/computeReadingProgress.ts`:
+
+```text
+computeReadingProgress(total: number, completed: number): ProgressDomain
+```
+
+- Devolve `null` se `total <= 0`.
+- Arredonda percentual `Math.round((completed / total) * 100)`.
+- Garante `completed <= total` (clamp por segurança).
+
+Testes unitários cobrem: total zero, completed zero, completed == total, completed > total (clamp), arredondamento (3/7 = 43%).
+
+### 5.8 Tipos
+
+`src/modules/schedule/types/readingProgress.types.ts`:
+
+```text
+type ProgressPersistence = {
+  book_id: string;
+  total: number;
+  completed: number;
+};
+
+type ProgressDomain = {
+  bookId: string;
+  total: number;
+  completed: number;
+  percentage: number;     // 0-100, inteiro
+};
+
+type ProgressByBookId = Map<string, ProgressDomain>;
+```
+
+---
+
+## 6. Fluxo de dados (E2E)
+
+### Cenário A — Usuário abre a Home com 5 livros em `reading`
+
+1. `useHome` resolve a página de livros (cache TanStack Query, RN19).
+2. `useHomeReadingProgressPrefetch` extrai `bookIds` em `reading`, chama `useReadingProgressMany`.
+3. `useReadingProgressMany` dispara `GET /api/schedule/progress?bookIds=...` (1 request).
+4. Rota chama a RPC; RPC devolve agregados; rota responde JSON.
+5. Cada `BookCard` consome `useReadingProgress(book.id)` que lê do cache populado e injeta no `<CardReadingProgressIndicator />`.
+6. Cards com `status !== "reading"` ou sem entrada no cache → `null` (FR-004 / FR-005).
+
+### Cenário B — Usuário marca uma linha como lida na tela de Cronograma
+
+1. `<ScheduleTable />` dispara `updateRead` (existente).
+2. `useOptimisticScheduleReadToggle.onMutate` atualiza o cache `["schedule", bookId, userId]` otimisticamente.
+3. `<ReadingProgressIndicator variant="page" />` é **reatividade pura**: deriva do mesmo array via `useScheduleReadingProgress(bookId)` → re-renderiza instantaneamente (SC-004 ≤ 100ms).
+4. Mutation resolve → `onSettled` invalida `["schedule", bookId, ...]` E o cache `many` da Home.
+5. Usuário volta à Home → na próxima montagem, `useReadingProgressMany` refetcha e atualiza o card.
+
+### Cenário C — Usuário em livro de leitura coletiva (`userX` e `userY` ambos como readers)
+
+1. `userX` logado abre Home. `useReadingProgressMany` chama a rota, que chama a RPC.
+2. A RPC filtra por `owner = auth.uid() = userX`. **Nunca** retorna linhas de `userY` (RN44 + defesa em profundidade na RPC).
+3. `userX` vê seu próprio progresso. SC-006 garantido por construção.
+
+---
+
+## 7. Plano de testes
+
+### 7.1 Unitários (Vitest)
+
+| Arquivo                                                            | Cobre                                                                                  |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| `computeReadingProgress.test.ts`                                   | Edge cases: zero, full, overshoot, arredondamento.                                     |
+| `readingProgressQueryKey.test.ts`                                  | Ordem estável, estabilidade entre montagens (RN18).                                    |
+| `readingProgress.service.test.ts`                                  | Curto-circuito em `[]`, montagem da URL, propagação de erros.                          |
+| `useReadingProgress.spec.ts`                                       | Leitura do cache many, fallback a `null` quando ausente.                               |
+| `useReadingProgressMany.spec.ts`                                   | `enabled: false` deslogado, montagem da queryKey, `staleTime`.                         |
+| `readingProgressIndicator.test.tsx`                                | Render condicional (sem dados → null), variants card/page, atributos ARIA.             |
+
+### 7.2 Integração / Rota
+
+| Arquivo                                  | Cobre                                                                                            |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `api/schedule/progress/route.test.ts`    | 401 sem sessão (RN20), 200 com sessão devolvendo apenas linhas do `auth.uid()` (RN44).            |
+
+### 7.3 Extensões a testes existentes
+
+- `useOptimisticScheduleReadToggle.spec.ts`: adicionar assert de que o `invalidateReadingProgressManyCaches` é chamado em `onSettled`.
+- `BookCard` testes existentes (se houver): assert de que `<CardReadingProgressIndicator />` NÃO é renderizado para `status !== "reading"` e para `isShelf === true`.
+
+### 7.4 Cobertura mínima (alinhado à diretriz `cobertura-fontes-abaixo-100pct.md`)
+
+- Service novo: 100% statements e branches.
+- Utils novos: 100%.
+- Hooks novos: ≥ 90% (mocks de `useQuery` / `queryClient`).
+- Rota nova: ≥ 90% (mock de `supabase.rpc`).
+- Componente: ≥ 90%.
+
+---
+
+## 8. Migração e implantação
+
+### 8.1 Ordem
+
+1. **Migration** (`supabase migration up`) — cria a RPC. Não toca tabelas; rollback trivial (`DROP FUNCTION`).
+2. **Backend route + service** — sem deploy quebrante (rota nova).
+3. **Hooks + componente** — sem deploy quebrante.
+4. **Wiring** no `BookCard` e na tela `/schedule` — visível para o usuário.
+
+### 8.2 Feature flag
+
+Não há necessidade. A ausência silenciosa (FR-004) cobre o caso de RPC falhar (try/catch + ErrorHandler) — o card e a tela degradam graciosamente sem indicador.
+
+### 8.3 Rollback
+
+- Reverter os deltas (3 arquivos: `bookCard.tsx`, `schedule/index.tsx`, `useOptimisticScheduleReadToggle.ts`).
+- Remover `DROP FUNCTION public.get_schedule_progress_for_books(uuid[])`.
+- Pastas novas podem ficar no repositório sem efeito (dead code) até remoção.
+
+---
+
+## 9. Conformidade com regras do projeto
+
+| Regra/diretriz                       | Como o plano endereça                                                                                       |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| **Hook-First + Logic Separation**    | Toda lógica nos hooks (`useReadingProgress*`, `useScheduleReadingProgress`); componentes apenas renderizam.  |
+| **Optimization (useCallback/useMemo)** | Hooks novos usarão `useMemo` para `progressByBookId` derivada e `useCallback` para selectors.              |
+| **Component Anatomy**                | Tipos em arquivos `types/*.types.ts` separados (jamais no arquivo do componente).                            |
+| **No underscore in component names** | Nomes: `ReadingProgressIndicator`, `CardReadingProgressIndicator`.                                          |
+| **No comments**                      | Código entregue sem comentários narrativos (apenas JSDoc em assinaturas públicas onde estritamente útil).   |
+| **Default exports + barrel**         | Cada nova pasta de componente/hook terá `index.ts` reexportando.                                            |
+| **Import organization**              | Bibliotecas externas → aliases (`@/`) → relativos; ordem alfabética; linha em branco entre blocos.           |
+| **Localização pt-BR**                | Todos os textos visíveis em pt-BR; `aria-label` em pt-BR (FR-009 / FR-014).                                  |
+| **RN44** (privacy)                   | RPC filtra `auth.uid()` + RLS já existente; SC-006 testado.                                                  |
+| **RN48** (API Routes)                | Rota nova usa `requireUser`. Mutação não aplicável (apenas GET).                                            |
+| **RN19** (staleTime)                 | `1000 * 60 * 5` consistente em `useReadingProgressMany`.                                                    |
+| **RN18** (cache key estável)         | `bookIds` ordenados alfabeticamente em `readingProgressManyQueryKey`.                                       |
+| **RN55** (BookCard isShelf)          | Indicador NUNCA renderizado quando `isShelf === true` (FR-007).                                              |
+
+---
+
+## 10. Estimativa e sequenciamento
+
+| Lote | Conteúdo                                                                                | Esforço      |
+| ---- | --------------------------------------------------------------------------------------- | ------------ |
+| **L1** | Migration RPC + testes manuais de SQL (REPL psql / Supabase Studio)                   | 1h           |
+| **L2** | Types + computeReadingProgress + queryKey utils + tests                               | 1h           |
+| **L3** | ReadingProgressService + tests                                                         | 1h           |
+| **L4** | Rota `/api/schedule/progress/route.ts` + tests                                         | 1h           |
+| **L5** | `useReadingProgressMany` + `useReadingProgress` + `useScheduleReadingProgress` + tests | 2h           |
+| **L6** | `<ReadingProgressIndicator />` + `<CardReadingProgressIndicator />` + tests           | 2h           |
+| **L7** | Wiring no `BookCard` (delta) + atualização do `useBookCard`                            | 30min        |
+| **L8** | Prefetch no `useHome` via `useHomeReadingProgressPrefetch`                             | 30min        |
+| **L9** | Wiring na tela `/schedule` (delta)                                                     | 15min        |
+| **L10**| Extensão do `useOptimisticScheduleReadToggle` (invalidação cross-key) + tests          | 30min        |
+| **L11**| Smoke E2E manual nas duas superfícies                                                  | 30min        |
+| **L12**| Atualização do vault (Second Brain) — promover RNxx-01..06 + nota da feature           | 30min        |
+
+**Total estimado:** ~10h de trabalho focado.
+
+---
+
+## 11. Riscos pós-Plan (acompanhar na fase Tasks/Implement)
+
+- **R-04 — RPC sem `auth.uid()` em ambiente de teste:** mocks de Supabase precisam responder corretamente. Mitigação: testes da rota com mock determinístico de `supabase.rpc`.
+- **R-05 — Cache "many" desalinhado quando o usuário pagina rapidamente:** TanStack Query deduplica por queryKey; como a key inclui o set de bookIds ordenado, paginar gera nova key → novo fetch. Aceitável.
+- **R-06 — Layout shift no `BookCard` quando o progresso chega depois:** mitigado retornando `null` durante loading no `variant="card"` (sem skeleton — evita "piscar"). Validar em smoke E2E.
+
+---
+
+## 12. Próximos passos (governança SDD)
+
+- Pós-aprovação deste Plan → executar `tasks` para gerar `tasks.md` (Fase 3) com a quebra por User Story.
+- Itens de spec marcados como `[NEEDS CLARIFICATION]` agora têm decisão registrada aqui (§2). Quando promover ao vault, atualizar RNxx-03 / FR-001 / FR-003 / FR-011 referenciando este Plan.

--- a/.sdd/specs/001-progresso-leitura-cronograma/spec.md
+++ b/.sdd/specs/001-progresso-leitura-cronograma/spec.md
@@ -1,0 +1,212 @@
+# Feature Specification: Progresso de Leitura Baseado no Cronograma
+
+**Feature ID:** 001
+**Status:** Draft
+**Owner:** Mateus
+**Criada em:** 2026-05-17
+**Domínios relacionados (vault):** [[features/feature-leitura-coletiva]] · [[telas-mobile/cronograma/tela-cronograma]] · [[business-rules]] (RN10, RN44)
+
+---
+
+## 1. Resumo executivo
+
+O usuário acompanha o avanço da leitura de um livro a partir do cronograma que ele próprio criou. Hoje, marcar capítulos como lidos exige abrir a tela `/schedule/[id]` e olhar a tabela linha a linha — não há nenhuma indicação **agregada** de quanto já foi lido daquele cronograma. A feature adiciona um **indicador visual de progresso de leitura** baseado no cronograma do livro, exibido em dois pontos da jornada do usuário:
+
+1. **No `BookCard` na Home** — para que o usuário enxergue, ao varrer a biblioteca, o quanto já avançou em cada livro **em leitura**.
+2. **No topo da tela de Cronograma** (`/schedule/[id]/[title]`) — para dar contexto imediato do progresso ao abrir a tela detalhada.
+
+O indicador é **derivado exclusivamente** do cronograma existente (não introduz nova fonte de verdade). Se o livro não tiver cronograma, o indicador é simplesmente **ocultado** — sem CTA, sem placeholder, sem ruído visual.
+
+---
+
+## 2. Por quê (motivação)
+
+- **Falta de feedback de avanço:** o usuário lê, marca dia a dia, mas perde a sensação de "estou no terço final" — informação que motiva continuar lendo.
+- **Custo cognitivo na Home:** hoje só o badge de status (`reading`, `finished`, etc.) aparece no card; não há nada que diferencie um livro em leitura recém-iniciado de um a uma sessão de terminar.
+- **Reaproveitamento do cronograma:** o cronograma já carrega todas as informações necessárias (linhas marcadas vs. total). A feature transforma esse dado já capturado em **valor exibido** sem pedir nada novo do usuário.
+- **Coerência com a regra existente RN44:** o cronograma é por `owner`, então o progresso é por usuário — naturalmente alinhado com a privacidade já consolidada.
+
+---
+
+## 3. Escopo
+
+### 3.1 Dentro do escopo
+
+- Cálculo e exibição de um **percentual de progresso** (e/ou representação visual equivalente) derivado do cronograma do usuário atual para o livro em questão.
+- Renderização do indicador:
+  - No `BookCard` exibido na **Home** (`modules/home`), respeitando a mesma instância de card usada em "Biblioteca / Todos / Leitura em Conjunto / Meus Livros".
+  - No **topo da tela de Cronograma** (`/schedule/[id]/[title]`), acima da `ScheduleTable`.
+- Restrição de visibilidade ao subconjunto de livros com `status = reading` (ver §6, FR-005).
+- Comportamento de **ocultar silenciosamente** o indicador quando não houver cronograma do usuário atual para o livro (ver §6, FR-004).
+
+### 3.2 Fora do escopo (não-objetivos)
+
+- **NÃO** introduzir nova coluna, nova tabela ou nova rota para persistir progresso. Tudo é derivado do `schedule` existente.
+- **NÃO** permitir marcar capítulos como lidos a partir do indicador na Home (interação fica apenas na tela de Cronograma, como já é hoje).
+- **NÃO** exibir o indicador em estantes customizadas (`BookCard` com `isShelf=true`), nem em modais de detalhe do livro, nem na tela de Citações. Caso essas superfícies queiram exibir o indicador no futuro, será uma extensão posterior.
+- **NÃO** exibir o indicador para visitantes (`anon`) ou em livros que não estejam em status `reading`.
+- **NÃO** alterar o `BookCard` quando usado em estantes (manter compatibilidade total com RN55).
+- **NÃO** considerar livros sem cronograma como "0% de progresso"; eles simplesmente não exibem o componente.
+
+---
+
+## 4. Personas e cenários
+
+### Persona única
+
+- **Leitor autenticado** que possui pelo menos um livro com status `reading` e cronograma definido por ele (`owner = auth.uid()` em `schedule`).
+
+### User Scenarios & Testing
+
+#### User Story 1 — Visualizar progresso de leitura na Home (Priority: **P1**)
+
+- **Descrição:** Como leitor logado, ao percorrer a Home, quero ver no card de cada livro **que estou lendo** uma indicação visual de quanto já avancei no cronograma daquele livro, para reconhecer rapidamente onde estou em cada leitura ativa.
+- **Razão da prioridade P1:** É o ganho principal de UX. Sem ele, o usuário continua precisando entrar na tela de cronograma de cada livro para ter qualquer noção de avanço. É o MVP da feature.
+- **Independent Test:**
+  - Logar como usuário com pelo menos 3 livros em estados distintos:
+    - Livro A: `status = reading`, cronograma com 10 linhas, 4 completadas.
+    - Livro B: `status = reading`, sem cronograma.
+    - Livro C: `status = finished`, cronograma com 10 linhas, 10 completadas.
+  - Abrir a Home.
+- **Acceptance Scenarios:**
+  - **Given** o usuário autenticado com o cenário acima, **When** a Home renderiza, **Then** apenas o card do Livro A exibe o indicador de progresso.
+  - **Given** o card do Livro A, **When** o indicador é renderizado, **Then** ele reflete um avanço equivalente a "4 de 10" do cronograma do próprio usuário.
+  - **Given** o card do Livro B, **When** renderiza, **Then** nenhum componente de progresso aparece e o layout do card não sofre nenhum gap visual residual.
+  - **Given** o card do Livro C (`finished`), **When** renderiza, **Then** o indicador também não aparece (escopo restrito a `reading`).
+
+#### User Story 2 — Visualizar progresso no topo da tela de Cronograma (Priority: **P1**)
+
+- **Descrição:** Como leitor logado, ao abrir a tela `/schedule/[id]/[title]` de um livro em leitura, quero ver um resumo do meu progresso no topo da tela, antes da tabela, para entender o contexto antes de mergulhar nas linhas.
+- **Razão da prioridade P1:** Reforça a sensação de avanço exatamente quando o usuário está prestes a marcar mais um dia. É barato implementar junto da User Story 1 porque consome o mesmo dado já carregado por `useSchedule`.
+- **Independent Test:**
+  - Logar como usuário com Livro A (acima).
+  - Navegar para `/schedule/<idA>/<tituloA>`.
+- **Acceptance Scenarios:**
+  - **Given** a tela carregou com schedule não-vazio, **When** o usuário visualiza a página, **Then** existe um indicador de progresso acima da `ScheduleTable`, refletindo o mesmo avanço exibido na Home.
+  - **Given** o usuário marca uma nova linha como lida (toggle existente), **When** a mutação otimista atualiza o estado, **Then** o indicador no topo da tela reflete o novo avanço imediatamente (sem refetch manual).
+  - **Given** o usuário entra na tela `/schedule/...` de um livro **sem cronograma** (estado `emptySchedule`), **When** a tela renderiza, **Then** o indicador **não aparece** e o fluxo atual de "criar cronograma" (`CreateScheduleForm`) segue inalterado.
+
+#### User Story 3 — Garantia de privacidade por usuário (Priority: **P2**)
+
+- **Descrição:** Como leitor logado em um livro de leitura coletiva, quero que o indicador reflita **apenas o meu cronograma**, ignorando o avanço de outros leitores do mesmo livro, para que o número exibido seja fiel à minha experiência.
+- **Razão da prioridade P2:** Não é uma feature visível ao usuário comum (ele nunca verá o cronograma alheio), mas é uma **invariante de correção** crítica que precisa estar testada para honrar a RN44.
+- **Independent Test:**
+  - Logar como `userX` em um livro com `readers = [userX, userY]` em status `reading`. Garantir que `userY` tem cronograma com 8/10 lidos e `userX` tem cronograma com 2/10 lidos.
+- **Acceptance Scenarios:**
+  - **Given** `userX` logado, **When** o card do livro coletivo renderiza na Home, **Then** o indicador reflete o progresso de `userX` (2/10) e nunca o de `userY`.
+  - **Given** `userX` logado, **When** abre `/schedule/<id>`, **Then** o indicador também reflete 2/10.
+
+---
+
+## 5. Regras de domínio (novas RNs propostas)
+
+> Estas regras serão promovidas ao vault em `01-Projetos/nosso-tbr/business-rules.md` após a entrega.
+
+- **RNxx-01 — Origem única do progresso:** O progresso de leitura exibido é derivado **exclusivamente** do conteúdo da tabela `schedule` (linhas do usuário atual para o `book_id` em questão). Não há outra fonte de verdade nem cache paralelo.
+- **RNxx-02 — Escopo do progresso:** O indicador só é considerado para exibição quando **todas** as condições abaixo são verdadeiras:
+  - Usuário autenticado.
+  - Livro com `status = reading`.
+  - Existe pelo menos uma linha em `schedule` com `owner = auth.uid()` e `book_id = <livro atual>`.
+  - Superfície de exibição é a Home (`BookCard` em contexto `isShelf=false`) **OU** a tela de Cronograma (`/schedule/[id]/[title]`).
+- **RNxx-03 — Definição de "lido":** Uma unidade de progresso é contada como **lida** quando a respectiva linha em `schedule` tem `completed = true`. Não há ponderação por número de capítulos da linha — cada linha do cronograma é uma unidade equivalente (a divisão diária já foi feita no momento da criação do cronograma).
+  - [NEEDS CLARIFICATION: confirmar se "1 linha = 1 unidade" é a expectativa, ou se o cálculo deve ponderar por quantidade de capítulos de cada linha — o que faria um dia com "Prólogo, 1-10" pesar mais que um dia com "11"].
+- **RNxx-04 — Privacidade do progresso:** O indicador reflete somente o cronograma do usuário autenticado (alinhado à RN44 já consolidada). O progresso de outros participantes de uma leitura coletiva **não** influencia o cálculo nem é visível.
+- **RNxx-05 — Ausência silenciosa:** Quando os critérios da RNxx-02 não são atendidos (livro sem cronograma do usuário, status diferente de `reading`, ou usuário não logado), o indicador é **omitido completamente da árvore renderizada**; não há placeholder, CTA, mensagem ou espaço reservado.
+- **RNxx-06 — Sincronia com toggle de leitura:** Quando o usuário marca/desmarca uma linha como lida na tela de Cronograma (fluxo otimista atual de `useOptimisticScheduleReadToggle`), o indicador exibido na mesma tela deve refletir a mudança **na mesma operação otimista**, sem requerer refetch separado.
+
+---
+
+## 6. Functional Requirements
+
+### 6.1 Cálculo e dados
+
+- **FR-001 — Cálculo do progresso:** O sistema DEVE derivar o progresso a partir da contagem de linhas do `schedule` do usuário atual para o livro, onde:
+  - **Total** = número total de linhas do cronograma do usuário para o livro.
+  - **Lidas** = número de linhas com `completed = true`.
+  - **Percentual** = `lidas / total` (arredondamento e formato visual definidos na fase de Plan).
+- **FR-002 — Fonte do dado:** O sistema DEVE usar exclusivamente o cronograma do usuário autenticado (`owner = auth.uid()`), conforme RN44 / RNxx-04. NÃO DEVE consultar cronogramas de outros usuários.
+- **FR-003 — Reaproveitamento de dados já carregados:** Quando os dados do cronograma já estão presentes em cache (ex.: usuário navegando entre Home → Cronograma → Home), o cálculo DEVE reutilizar o cache existente; não DEVE disparar requisição extra dedicada ao indicador.
+  - [NEEDS CLARIFICATION: a Home hoje não carrega `schedule` por padrão para cada card; precisamos decidir na fase Plan se o cálculo é feito a partir de um endpoint agregado novo, ou se cada card dispara seu próprio fetch. Marcar como decisão técnica para o Plan].
+
+### 6.2 Exibição
+
+- **FR-004 — Ausência silenciosa:** O sistema DEVE ocultar completamente o indicador quando o livro não tiver cronograma do usuário, sem placeholder, sem CTA e sem alterar o layout do card além da remoção do componente.
+- **FR-005 — Escopo de status:** O sistema DEVE exibir o indicador apenas para livros com `status = reading`. Livros em `not_started`, `planned`, `paused`, `abandoned` ou `finished` NÃO DEVEM exibir o indicador, mesmo que possuam cronograma.
+- **FR-006 — Escopo de superfície:** O sistema DEVE exibir o indicador em duas superfícies, e somente nelas:
+  1. `BookCard` quando renderizado na **Home** (contexto `isShelf = false`, conforme RN55).
+  2. Topo da página `/schedule/[id]/[title]`, acima da `ScheduleTable`.
+- **FR-007 — Exclusão explícita do contexto Estante:** O sistema NÃO DEVE renderizar o indicador no `BookCard` quando este estiver em contexto de estante (`isShelf = true`), para preservar a densidade visual do card de estante e manter compatibilidade com RN55.
+- **FR-008 — Exclusão para visitantes:** O sistema NÃO DEVE renderizar o indicador para usuários anônimos, alinhado a RN20 e RN41.
+- **FR-009 — Pt-BR:** Todos os rótulos e textos auxiliares do indicador (ex.: "lido", "concluído", "x de y") DEVEM estar em pt-BR, alinhados à diretriz global de localização do projeto.
+
+### 6.3 Comportamento dinâmico
+
+- **FR-010 — Reflexo do toggle otimista:** Quando uma linha do cronograma é marcada/desmarcada na tela de Cronograma via o fluxo otimista existente, o indicador na mesma tela DEVE refletir a alteração imediatamente, sem refetch dedicado.
+- **FR-011 — Reflexo entre superfícies (best-effort):** Quando o usuário retorna à Home após marcar linhas no Cronograma, o indicador na Home DEVE refletir o novo progresso na próxima renderização do `BookCard`, dentro das políticas de cache TanStack Query já em uso (RN19 — `staleTime` consistente).
+  - [NEEDS CLARIFICATION: confirmar se queremos invalidação ativa cross-screen ou se o comportamento padrão de `staleTime` é aceitável. Decisão técnica para fase Plan].
+
+### 6.4 Erros e estados de carregamento
+
+- **FR-012 — Estado de carregamento:** Enquanto os dados de progresso de um card específico ainda não foram resolvidos, o sistema DEVE evitar exibir um valor parcial ou incorreto. A estratégia exata (skeleton, valor escondido, animação de loading) será definida na fase Plan.
+- **FR-013 — Erros silenciosos:** Falhas ao calcular o progresso (ex.: erro de rede ao buscar cronograma) NÃO DEVEM bloquear o restante do card nem da tela; o indicador simplesmente não é renderizado nessa amostra, e o card mantém todo o restante de seu comportamento padrão.
+
+### 6.5 Acessibilidade
+
+- **FR-014 — Acessibilidade do indicador:** O indicador visual DEVE expor sua semântica de progresso a tecnologias assistivas (rótulo textual descritivo do tipo "X de Y leituras concluídas" ou equivalente). Não DEVE depender apenas de cor para transmitir a informação.
+
+---
+
+## 7. Success Criteria
+
+- **SC-001 — Adoção visual:** 100% dos livros em status `reading` que possuem cronograma do usuário atual exibem o indicador no `BookCard` da Home (verificado via inspeção manual e testes automatizados).
+- **SC-002 — Zero falsos positivos:** Nenhum livro em status diferente de `reading` exibe o indicador, e nenhum livro sem cronograma do usuário atual exibe placeholder.
+- **SC-003 — Correção do valor:** Em uma amostra de 5 livros com cronogramas conhecidos, o percentual exibido coincide com a contagem manual `linhas_completed / total_linhas` em 100% dos casos.
+- **SC-004 — Sincronia otimista:** Após marcar uma linha como lida na tela de Cronograma, o indicador da mesma tela atualiza em ≤ 100ms (mesma operação otimista de `useOptimisticScheduleReadToggle`).
+- **SC-005 — Não regressão da Home:** Tempo de primeira renderização da Home (FCP/LCP no fluxo logado com 8 livros) não piora em mais de 10% comparado à medição atual.
+- **SC-006 — Isolamento por usuário:** Em teste com livro de leitura coletiva entre dois usuários, cada um vê apenas o seu próprio percentual (verificado via E2E ou teste integrado).
+- **SC-007 — Acessibilidade:** Auditoria automatizada (axe ou equivalente) não reporta novas violações relacionadas ao indicador.
+
+---
+
+## 8. Riscos, dependências e premissas
+
+### 8.1 Premissas
+
+- A tabela `schedule` continua sendo a fonte canônica do cronograma, isolada por `owner` (RN44).
+- O componente `BookCard` continua sendo usado tanto na Home (`isShelf=false`) quanto em estantes (`isShelf=true`) — a feature respeita essa diferenciação (RN55).
+- O status `reading` continua sendo um valor explícito da coluna `books.status` (RN10 / RN17).
+
+### 8.2 Riscos
+
+- **R-01 — Custo de fetch na Home:** Calcular progresso para N cards na Home pode demandar N requisições adicionais se não houver endpoint agregado. Mitigação: decidir na fase Plan se o backend deve expor um endpoint agregado ou se o frontend prefetcha em lote. Marcado como [NEEDS CLARIFICATION] em FR-003.
+- **R-02 — Cache desalinhado:** Se o cache do schedule for atualizado em uma tela e a Home não invalidar, o usuário pode ver progresso desatualizado momentaneamente. Mitigação: política de `staleTime` já consolidada (RN19); decidir invalidação ativa na fase Plan.
+- **R-03 — Compreensão visual:** Um indicador mal calibrado (cores, posição, tamanho) pode poluir o card. Mitigação: validar visual com Figma/protótipo na fase Plan; manter card íntegro quando ausente (FR-004).
+
+### 8.3 Dependências internas
+
+- Módulo `schedule` (`src/modules/schedule/`) — fonte do dado.
+- Componente `BookCard` (`src/components/bookCard/`) — superfície na Home (RN55).
+- Tela `/schedule/[id]/[title]` (`src/app/(main)/schedule/...` e `src/modules/schedule/index.tsx`) — segunda superfície.
+- Stores e hooks já existentes: `useUserStore`, `useSchedule`, `useOptimisticScheduleReadToggle`.
+
+### 8.4 Dependências externas
+
+- Nenhuma. A feature é 100% derivada de dados já capturados pelo sistema.
+
+---
+
+## 9. Itens marcados como [NEEDS CLARIFICATION]
+
+1. **Unidade do cálculo (RNxx-03 / FR-001):** "1 linha do cronograma = 1 unidade" ou ponderar por quantidade real de capítulos da linha?
+2. **Estratégia de fetch na Home (FR-003 / R-01):** endpoint agregado novo no backend OU fetch por card no frontend OU prefetch em lote ao carregar a Home?
+3. **Invalidação cross-screen (FR-011):** invalidação ativa ao retornar à Home pós-toggle, ou aceitar o comportamento padrão de `staleTime`?
+
+> Esses itens **não impedem** o avanço para a fase Plan, mas devem ser resolvidos como decisões técnicas explícitas antes da fase Tasks.
+
+---
+
+## 10. Notas de governança SDD
+
+- Fase atual: **Specify (concluída quando esta spec for aprovada).**
+- Próxima fase: **Plan** — definirá stack (já consolidado no projeto: Next.js 15 / React 19 / TanStack Query / TS estrito), arquitetura Hook-First, contratos de hook e (se necessário) novo endpoint agregado.
+- Após a entrega: promover RNxx-01..06 à seção apropriada de `01-Projetos/nosso-tbr/business-rules.md` no vault e criar nota dedicada em `01-Projetos/nosso-tbr/features/feature-progresso-leitura-cronograma.md`.

--- a/src/app/api/schedule/progress/route.test.ts
+++ b/src/app/api/schedule/progress/route.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+
+const OWNER_ID = "660e8400-e29b-41d4-a716-446655440002";
+const BOOK_A = "550e8400-e29b-41d4-a716-446655440001";
+const BOOK_B = "550e8400-e29b-41d4-a716-446655440002";
+
+type Client = {
+  auth: { getUser: ReturnType<typeof vi.fn> };
+  rpc: ReturnType<typeof vi.fn>;
+};
+
+async function loadRoute(client: Client) {
+  vi.resetModules();
+  vi.doMock("@/lib/supabase/server", () => ({
+    createClient: vi.fn().mockResolvedValue(client),
+  }));
+  return import("./route");
+}
+
+function makeClient(rpcResult: {
+  data?: unknown;
+  error?: { message: string } | null;
+}, userId: string | null = OWNER_ID): Client {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? { id: userId } : null },
+        error: null,
+      }),
+    },
+    rpc: vi.fn().mockResolvedValue(rpcResult),
+  };
+}
+
+describe("GET /api/schedule/progress", () => {
+  it("retorna 401 sem sessão (RN20)", async () => {
+    const client = makeClient({ data: [], error: null }, null);
+    const route = await loadRoute(client);
+    const res = await route.GET(
+      new Request(`http://localhost/api/schedule/progress?bookIds=${BOOK_A}`),
+    );
+    expect(res.status).toBe(401);
+    expect(client.rpc).not.toHaveBeenCalled();
+  });
+
+  it("retorna 400 quando bookIds está ausente", async () => {
+    const client = makeClient({ data: [], error: null });
+    const route = await loadRoute(client);
+    const res = await route.GET(
+      new Request("http://localhost/api/schedule/progress"),
+    );
+    expect(res.status).toBe(400);
+    expect(client.rpc).not.toHaveBeenCalled();
+  });
+
+  it("retorna 400 quando bookIds está vazio após split", async () => {
+    const client = makeClient({ data: [], error: null });
+    const route = await loadRoute(client);
+    const res = await route.GET(
+      new Request("http://localhost/api/schedule/progress?bookIds=,,,"),
+    );
+    expect(res.status).toBe(400);
+    expect(client.rpc).not.toHaveBeenCalled();
+  });
+
+  it("retorna 400 quando algum bookId não é UUID válido", async () => {
+    const client = makeClient({ data: [], error: null });
+    const route = await loadRoute(client);
+    const res = await route.GET(
+      new Request(
+        `http://localhost/api/schedule/progress?bookIds=${BOOK_A},nao-uuid`,
+      ),
+    );
+    expect(res.status).toBe(400);
+    expect(client.rpc).not.toHaveBeenCalled();
+  });
+
+  it("retorna 400 quando excede o limite de bookIds", async () => {
+    const client = makeClient({ data: [], error: null });
+    const route = await loadRoute(client);
+    const tooMany = Array.from({ length: 101 }, () => BOOK_A).join(",");
+    const res = await route.GET(
+      new Request(`http://localhost/api/schedule/progress?bookIds=${tooMany}`),
+    );
+    expect(res.status).toBe(400);
+    expect(client.rpc).not.toHaveBeenCalled();
+  });
+
+  it("retorna 200 com array vazio quando RPC não retorna nenhuma linha", async () => {
+    const client = makeClient({ data: [], error: null });
+    const route = await loadRoute(client);
+    const res = await route.GET(
+      new Request(`http://localhost/api/schedule/progress?bookIds=${BOOK_A}`),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    await expect(res.json()).resolves.toEqual([]);
+  });
+
+  it("retorna 200 e propaga o payload da RPC", async () => {
+    const payload = [
+      { book_id: BOOK_A, total: 10, completed: 4 },
+      { book_id: BOOK_B, total: 5, completed: 5 },
+    ];
+    const client = makeClient({ data: payload, error: null });
+    const route = await loadRoute(client);
+    const res = await route.GET(
+      new Request(
+        `http://localhost/api/schedule/progress?bookIds=${BOOK_A},${BOOK_B}`,
+      ),
+    );
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual(payload);
+    expect(client.rpc).toHaveBeenCalledWith("get_schedule_progress_for_books", {
+      book_ids: [BOOK_A, BOOK_B],
+    });
+  });
+
+  it("trim e dedup vazios mas preserva UUIDs com espaços externos", async () => {
+    const client = makeClient({ data: [], error: null });
+    const route = await loadRoute(client);
+    const res = await route.GET(
+      new Request(
+        `http://localhost/api/schedule/progress?bookIds=${encodeURIComponent(
+          ` ${BOOK_A} , ${BOOK_B} `,
+        )}`,
+      ),
+    );
+    expect(res.status).toBe(200);
+    expect(client.rpc).toHaveBeenCalledWith("get_schedule_progress_for_books", {
+      book_ids: [BOOK_A, BOOK_B],
+    });
+  });
+
+  it("retorna 500 quando a RPC falha", async () => {
+    const client = makeClient({
+      data: null,
+      error: { message: "rpc error" },
+    });
+    const route = await loadRoute(client);
+    const res = await route.GET(
+      new Request(`http://localhost/api/schedule/progress?bookIds=${BOOK_A}`),
+    );
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: "rpc error" });
+  });
+});

--- a/src/app/api/schedule/progress/route.ts
+++ b/src/app/api/schedule/progress/route.ts
@@ -1,0 +1,57 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { requireUser } from "@/app/api/_utils/requireUser";
+
+const MAX_BOOK_IDS = 100;
+
+const querySchema = z.object({
+  bookIds: z
+    .string()
+    .min(1, "bookIds required")
+    .transform((value) =>
+      value
+        .split(",")
+        .map((id) => id.trim())
+        .filter(Boolean),
+    )
+    .pipe(
+      z
+        .array(z.string().uuid({ message: "Invalid bookId UUID" }))
+        .min(1, "bookIds required")
+        .max(MAX_BOOK_IDS, `Too many bookIds (max ${MAX_BOOK_IDS})`),
+    ),
+});
+
+const NO_STORE_HEADERS = { "Cache-Control": "no-store" } as const;
+
+export async function GET(request: Request) {
+  const supabase = await createClient();
+  const auth = await requireUser(supabase);
+  if (auth.errorResponse) return auth.errorResponse;
+
+  const url = new URL(request.url);
+  const raw = url.searchParams.get("bookIds") ?? "";
+
+  const parsed = querySchema.safeParse({ bookIds: raw });
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid bookIds", details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await supabase.rpc(
+    "get_schedule_progress_for_books",
+    { book_ids: parsed.data.bookIds },
+  );
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json(data ?? [], {
+    status: 200,
+    headers: NO_STORE_HEADERS,
+  });
+}

--- a/src/components/bookCard/bookCard.tsx
+++ b/src/components/bookCard/bookCard.tsx
@@ -7,6 +7,7 @@ import BookCardDetailsModal from "./components/bookCardDetailsModal";
 import { AddBookToShelf } from "./components/addBookToShelf";
 import { DropdownBook } from "./components/dropdownBook";
 import { BookUpsert } from "@/modules/bookUpsert";
+import { CardReadingProgressIndicator } from "@/modules/schedule/components/readingProgressIndicator";
 import { ConfirmDialog } from "@/components/confirmDialog";
 import {
   Tooltip,
@@ -46,16 +47,25 @@ export function BookCard(props: BookCardProps) {
     handleFavoriteClick,
     isFavoritePending,
     canAccessCollectiveReading,
+    showReadingProgress,
   } = useBookCard(props);
 
-  const showTopActions =
-    showFavoriteToggle || (isLogged && !hideInteractions);
-  const showReadersOnCard =
-    isLogged && Boolean(book.readersDisplay?.trim());
+  const showTopActions = showFavoriteToggle || (isLogged && !hideInteractions);
+  const showReadersOnCard = isLogged && Boolean(book.readersDisplay?.trim());
 
   const coverSizes = isShelf
-    ? { width: 56, height: 92, className: "relative h-[92px] w-14 shrink-0 overflow-hidden rounded-md bg-muted/20 shadow-sm" }
-    : { width: 90, height: 130, className: "relative h-[130px] w-[90px] shrink-0 overflow-hidden rounded-md shadow-sm" };
+    ? {
+        width: 56,
+        height: 92,
+        className:
+          "relative h-[92px] w-14 shrink-0 overflow-hidden rounded-md bg-muted/20 shadow-sm",
+      }
+    : {
+        width: 90,
+        height: 130,
+        className:
+          "relative h-[130px] w-[90px] shrink-0 overflow-hidden rounded-md shadow-sm",
+      };
 
   const pagesLabel = formatBookPagesLabel(book.pages);
 
@@ -106,7 +116,9 @@ export function BookCard(props: BookCardProps) {
             <p
               className={cn(
                 "min-w-0 text-zinc-600 dark:text-zinc-400",
-                isShelf ? "line-clamp-1 text-[11px]" : "line-clamp-2 text-xs leading-snug",
+                isShelf
+                  ? "line-clamp-1 text-[11px]"
+                  : "line-clamp-2 text-xs leading-snug",
               )}
             >
               {book.author}
@@ -120,7 +132,9 @@ export function BookCard(props: BookCardProps) {
           <p
             className={cn(
               "shrink-0 tabular-nums text-zinc-500 dark:text-zinc-500",
-              isShelf ? "text-[10px] leading-tight" : "text-[11px] leading-tight",
+              isShelf
+                ? "text-[10px] leading-tight"
+                : "text-[11px] leading-tight",
             )}
           >
             {pagesLabel}
@@ -130,8 +144,10 @@ export function BookCard(props: BookCardProps) {
         {(showReadersOnCard || statusDisplay) && (
           <div
             className={cn(
-              "mt-auto flex min-w-0 flex-col",
+              "flex min-w-0 flex-col",
               isShelf ? "gap-1" : "gap-1.5",
+              !(showReadingProgress && !isShelf) && "mt-auto",
+              showReadingProgress && !isShelf && "mt-1",
             )}
           >
             {showReadersOnCard && (
@@ -219,94 +235,112 @@ export function BookCard(props: BookCardProps) {
             : "border-zinc-200 bg-zinc-50/30 dark:border-zinc-800 dark:bg-zinc-900/40 transition-shadow duration-200 hover:shadow-md",
         )}
       >
-        <CardContent className={cn(isShelf ? "p-2" : "p-3")}>
+        <CardContent
+          className={cn(
+            isShelf ? "p-2" : "p-3",
+            showReadingProgress && !isShelf && "pb-3 pt-3",
+          )}
+        >
           <div
-            className={cn("flex min-w-0", isShelf ? "gap-2.5" : "gap-3")}
+            className={cn(
+              "flex min-w-0 flex-col",
+              showReadingProgress && !isShelf ? "gap-2.5" : "gap-0",
+            )}
           >
-            {bookMain}
-            {showTopActions && (
-              <div
-                className={cn(
-                  "flex shrink-0 flex-col items-end gap-0.5",
-                  isShelf ? "pt-px" : "pt-px",
-                )}
-                onClick={(e) => e.stopPropagation()}
-                onKeyDown={(e) => e.stopPropagation()}
-              >
-                {showFavoriteToggle && (
-                  <button
-                    type="button"
-                    onClick={handleFavoriteClick}
-                    disabled={isFavoritePending}
-                    title={
-                      book.is_favorite
-                        ? "Remover dos favoritos (também no menu ⋮)"
-                        : "Marcar como favorito (também no menu ⋮)"
-                    }
-                    aria-label={
-                      book.is_favorite
-                        ? `Remover "${book.title}" dos favoritos`
-                        : `Marcar "${book.title}" como favorito`
-                    }
-                    aria-pressed={book.is_favorite}
-                    className={cn(
-                      "flex cursor-pointer items-center justify-center rounded-full border transition-colors duration-200 disabled:opacity-60",
-                      isShelf ? "h-7 w-7" : "h-9 w-9",
-                      book.is_favorite
-                        ? "border-rose-200 bg-rose-50 text-rose-500 hover:bg-rose-100 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-400 dark:hover:bg-rose-950/60"
-                        : "border-zinc-200 bg-zinc-50/80 text-zinc-400 hover:border-rose-200 hover:text-rose-500 dark:border-zinc-700 dark:bg-zinc-800/50 dark:text-zinc-400 dark:hover:border-rose-800 dark:hover:text-rose-400",
-                    )}
-                  >
-                    <Heart
+            <div className={cn("flex min-w-0", isShelf ? "gap-2.5" : "gap-3")}>
+              {bookMain}
+              {showTopActions && (
+                <div
+                  className={cn(
+                    "flex shrink-0 flex-col items-end gap-0.5",
+                    isShelf ? "pt-px" : "pt-px",
+                  )}
+                  onClick={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => e.stopPropagation()}
+                >
+                  {showFavoriteToggle && (
+                    <button
+                      type="button"
+                      onClick={handleFavoriteClick}
+                      disabled={isFavoritePending}
+                      title={
+                        book.is_favorite
+                          ? "Remover dos favoritos (também no menu ⋮)"
+                          : "Marcar como favorito (também no menu ⋮)"
+                      }
+                      aria-label={
+                        book.is_favorite
+                          ? `Remover "${book.title}" dos favoritos`
+                          : `Marcar "${book.title}" como favorito`
+                      }
+                      aria-pressed={book.is_favorite}
                       className={cn(
-                        isShelf ? "h-3 w-3" : "h-4 w-4",
-                        book.is_favorite && "fill-current",
+                        "flex cursor-pointer items-center justify-center rounded-full border transition-colors duration-200 disabled:opacity-60",
+                        isShelf ? "h-7 w-7" : "h-9 w-9",
+                        book.is_favorite
+                          ? "border-rose-200 bg-rose-50 text-rose-500 hover:bg-rose-100 dark:border-rose-900/50 dark:bg-rose-950/40 dark:text-rose-400 dark:hover:bg-rose-950/60"
+                          : "border-zinc-200 bg-zinc-50/80 text-zinc-400 hover:border-rose-200 hover:text-rose-500 dark:border-zinc-700 dark:bg-zinc-800/50 dark:text-zinc-400 dark:hover:border-rose-800 dark:hover:text-rose-400",
                       )}
-                      aria-hidden
-                    />
-                  </button>
-                )}
-                {isLogged && !hideInteractions && (
-                  <DropdownBook
-                    isOpen={dropdownModal.isOpen}
-                    onOpenChange={dropdownModal.setIsOpen}
-                    onToggleFavorite={() => handleFavoriteClick()}
-                    isFavorite={book.is_favorite}
-                    favoriteActionBusy={isFavoritePending}
-                    trigger={
-                      <button
-                        type="button"
-                        aria-label={`Mais opções para "${book.title}"`}
+                    >
+                      <Heart
                         className={cn(
-                          "flex shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors duration-200 hover:bg-zinc-100 active:opacity-70 dark:hover:bg-zinc-800",
-                          isShelf ? "h-8 w-8" : "h-11 w-11",
+                          isShelf ? "h-3 w-3" : "h-4 w-4",
+                          book.is_favorite && "fill-current",
                         )}
-                      >
-                        <EllipsisVerticalIcon
+                        aria-hidden
+                      />
+                    </button>
+                  )}
+                  {isLogged && !hideInteractions && (
+                    <DropdownBook
+                      isOpen={dropdownModal.isOpen}
+                      onOpenChange={dropdownModal.setIsOpen}
+                      onToggleFavorite={() => handleFavoriteClick()}
+                      isFavorite={book.is_favorite}
+                      favoriteActionBusy={isFavoritePending}
+                      trigger={
+                        <button
+                          type="button"
+                          aria-label={`Mais opções para "${book.title}"`}
                           className={cn(
-                            "text-zinc-400",
-                            isShelf ? "size-3.5" : "size-4",
+                            "flex shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors duration-200 hover:bg-zinc-100 active:opacity-70 dark:hover:bg-zinc-800",
+                            isShelf ? "h-8 w-8" : "h-11 w-11",
                           )}
-                          aria-hidden
-                          onTouchStart={dropdownTap.handleTouchStart}
-                          onTouchEnd={dropdownTap.handleTouchEnd}
-                          onClick={dropdownTap.handleClick}
-                        />
-                      </button>
-                    }
-                    editBook={() => dialogEditModal.setIsOpen(true)}
-                    removeBook={() => dialogDeleteModal.setIsOpen(true)}
-                    removeBookLabel={
-                      isShelf ? "Remover livro da estante" : "Remover livro"
-                    }
-                    addToShelf={() => dialogAddShelfModal.setIsOpen(true)}
-                    shareOnWhatsApp={shareOnWhatsApp}
-                    schedule={handleNavigateToSchedule}
-                    quotes={handleNavigateToQuotes}
-                    isFinishedReading={book.status === "finished"}
-                    quotesDisabled={book.status !== "not_started"}
-                  />
-                )}
+                        >
+                          <EllipsisVerticalIcon
+                            className={cn(
+                              "text-zinc-400",
+                              isShelf ? "size-3.5" : "size-4",
+                            )}
+                            aria-hidden
+                            onTouchStart={dropdownTap.handleTouchStart}
+                            onTouchEnd={dropdownTap.handleTouchEnd}
+                            onClick={dropdownTap.handleClick}
+                          />
+                        </button>
+                      }
+                      editBook={() => dialogEditModal.setIsOpen(true)}
+                      removeBook={() => dialogDeleteModal.setIsOpen(true)}
+                      removeBookLabel={
+                        isShelf ? "Remover livro da estante" : "Remover livro"
+                      }
+                      addToShelf={() => dialogAddShelfModal.setIsOpen(true)}
+                      shareOnWhatsApp={shareOnWhatsApp}
+                      schedule={handleNavigateToSchedule}
+                      quotes={handleNavigateToQuotes}
+                      isFinishedReading={book.status === "finished"}
+                      quotesDisabled={book.status !== "not_started"}
+                    />
+                  )}
+                </div>
+              )}
+            </div>
+            {showReadingProgress && !isShelf && (
+              <div className="min-w-0 border-t border-zinc-200/80 pt-2.5 dark:border-zinc-800/80">
+                <CardReadingProgressIndicator
+                  bookId={book.id}
+                  onNavigateToSchedule={handleNavigateToSchedule}
+                />
               </div>
             )}
           </div>

--- a/src/components/bookCard/hooks/useBookCard.ts
+++ b/src/components/bookCard/hooks/useBookCard.ts
@@ -221,6 +221,9 @@ export function useBookCard({
   const showFavoriteToggle =
     !hideInteractions && isLogged && book.status === "finished";
 
+  const showReadingProgress =
+    isLogged && !isShelf && book.status === "reading";
+
   const handleFavoriteClick = useCallback(
     (event?: MouseEvent<HTMLButtonElement>) => {
       event?.preventDefault();
@@ -259,5 +262,6 @@ export function useBookCard({
     canAccessCollectiveReading,
     collectiveReadingHref,
     handleNavigateToCollectiveReading,
+    showReadingProgress,
   };
 }

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -5,11 +5,16 @@ import * as ProgressPrimitive from "@radix-ui/react-progress"
 
 import { cn } from "@/lib/utils"
 
+type ProgressProps = React.ComponentProps<typeof ProgressPrimitive.Root> & {
+  indicatorClassName?: string
+}
+
 function Progress({
   className,
   value,
+  indicatorClassName,
   ...props
-}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+}: ProgressProps) {
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
@@ -21,7 +26,10 @@ function Progress({
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="bg-primary h-full w-full flex-1 transition-all"
+        className={cn(
+          "bg-primary h-full w-full flex-1 motion-safe:transition-transform motion-safe:duration-500 motion-safe:ease-out",
+          indicatorClassName
+        )}
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>

--- a/src/modules/home/hooks/useHome.test.ts
+++ b/src/modules/home/hooks/useHome.test.ts
@@ -830,10 +830,16 @@ describe("useHome", () => {
 
       const { result } = setupHook({ view: "todos", readers: ["2"] });
 
-      const key = (useQuery as Mock).mock.calls
-        .at(-1)?.[0]?.queryKey?.find(
-          (k: unknown) => typeof k === "string" && k.startsWith("1"),
-        );
+      const booksCall = (useQuery as Mock).mock.calls
+        .map((call) => call[0]?.queryKey as unknown[] | undefined)
+        .filter(
+          (queryKey): queryKey is unknown[] =>
+            Array.isArray(queryKey) && queryKey[0] === "books",
+        )
+        .at(-1);
+      const key = booksCall?.find(
+        (k: unknown) => typeof k === "string" && k.startsWith("1"),
+      );
       expect(key).toContain("1");
       expect(result.current.lockedReaderId).toBeUndefined();
     });

--- a/src/modules/home/hooks/useHome.ts
+++ b/src/modules/home/hooks/useHome.ts
@@ -19,6 +19,7 @@ import { sortWithPriority } from "../utils";
 import { UserSocialService } from "@/services/userSocial/userSocial.service";
 import { useBookSearchRefinement } from "./useBookSearchRefinement";
 import { useBookFavoriteIds } from "@/services/bookFavorites/hooks/useBookFavoriteIds";
+import { useHomeReadingProgressBatch } from "./useHomeReadingProgressBatch";
 
 const PAGE_SIZE = 8;
 const JOINT_READINGS_FETCH_SIZE = 2000;
@@ -699,6 +700,8 @@ export function useHome() {
     [isFollowingFeedActive, isLoadingFollowingIds, followingIds.length],
   );
 
+  const readingProgressBatch = useHomeReadingProgressBatch(allBooks?.data);
+
   return {
     allBooks,
     isLoadingAllBooks: isLoadingData,
@@ -743,5 +746,6 @@ export function useHome() {
     readers,
     lockedReaderId,
     needsExtraReader,
+    readingProgressBatch,
   };
 }

--- a/src/modules/home/hooks/useHomeReadingProgressBatch.ts
+++ b/src/modules/home/hooks/useHomeReadingProgressBatch.ts
@@ -1,0 +1,28 @@
+import { useMemo } from "react";
+import type { BookDomain } from "@/types/books.types";
+import { useReadingProgressMany } from "@/modules/schedule/hooks/useReadingProgressMany";
+
+export function useHomeReadingProgressBatch(books: BookDomain[] | undefined) {
+  const readingBookIds = useMemo(() => {
+    if (!books || books.length === 0) return [] as string[];
+    return books
+      .filter(
+        (book): book is BookDomain & { id: string } =>
+          book.status === "reading" && typeof book.id === "string",
+      )
+      .map((book) => book.id);
+  }, [books]);
+
+  const { progressByBookId, isLoading, isError } =
+    useReadingProgressMany(readingBookIds);
+
+  return useMemo(
+    () => ({
+      readingBookIds,
+      progressByBookId,
+      isLoading,
+      isError,
+    }),
+    [readingBookIds, progressByBookId, isLoading, isError],
+  );
+}

--- a/src/modules/home/index.test.tsx
+++ b/src/modules/home/index.test.tsx
@@ -53,6 +53,12 @@ const { baseUseHome } = vi.hoisted(() => ({
     readers: [],
     lockedReaderId: undefined,
     needsExtraReader: false,
+    readingProgressBatch: {
+      readingBookIds: [],
+      progressByBookId: new Map(),
+      isLoading: false,
+      isError: false,
+    },
   },
 }));
 

--- a/src/modules/home/index.tsx
+++ b/src/modules/home/index.tsx
@@ -13,6 +13,7 @@ import {
   StatusFilterChips,
   YearFilterChips,
 } from "@/components";
+import { ScheduleProgressBatchContext } from "@/modules/schedule/context/scheduleProgressBatchContext";
 import { CreateEditBookshelves } from "../shelves/components/createEditBookshelves";
 import { useUserStore } from "@/stores/userStore";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -67,6 +68,7 @@ export default function ClientHome() {
     readers,
     lockedReaderId,
     needsExtraReader,
+    readingProgressBatch,
   } = useHome();
 
   const dialogModal = useModal();
@@ -490,22 +492,24 @@ export default function ClientHome() {
           </div>
         </div>
       ) : (
-        <ListGrid<BookDomain>
-          items={allBooks?.data ?? []}
-          isLoading={isLoading}
-          isFetched={isFetched}
-          renderItem={(book) => (
-            <BookCard key={book.id} book={book} isShelf={false} />
-          )}
-          emptyMessage={
-            filters.bookId?.trim()
-              ? "Não encontramos um livro com este identificador na sua lista."
-              : followingFeedEmpty
-                ? "Siga outros leitores pelo perfil para ver livros nesta visão."
-                : "Nenhum livro encontrado para os filtros selecionados."
-          }
-          isError={isError}
-        />
+        <ScheduleProgressBatchContext.Provider value={readingProgressBatch}>
+          <ListGrid<BookDomain>
+            items={allBooks?.data ?? []}
+            isLoading={isLoading}
+            isFetched={isFetched}
+            renderItem={(book) => (
+              <BookCard key={book.id} book={book} isShelf={false} />
+            )}
+            emptyMessage={
+              filters.bookId?.trim()
+                ? "Não encontramos um livro com este identificador na sua lista."
+                : followingFeedEmpty
+                  ? "Siga outros leitores pelo perfil para ver livros nesta visão."
+                  : "Nenhum livro encontrado para os filtros selecionados."
+            }
+            isError={isError}
+          />
+        </ScheduleProgressBatchContext.Provider>
       )}
 
       {!isLoading && totalPages > 1 && (

--- a/src/modules/schedule/components/readingProgressIndicator/cardReadingProgressIndicator.tsx
+++ b/src/modules/schedule/components/readingProgressIndicator/cardReadingProgressIndicator.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { CalendarPlus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+import { useBookCardScheduleProgress } from "../../hooks/useBookCardScheduleProgress";
+import { ReadingProgressIndicator } from "./readingProgressIndicator";
+import type { CardReadingProgressIndicatorProps } from "./types/readingProgressIndicator.types";
+
+function CardReadingProgressIndicator({
+  bookId,
+  onNavigateToSchedule,
+  className,
+}: CardReadingProgressIndicatorProps) {
+  const { progress, isLoading, isError, showNoScheduleCta } =
+    useBookCardScheduleProgress(bookId);
+
+  if (!bookId) {
+    return null;
+  }
+
+  if (isLoading) {
+    return (
+      <div className={cn("w-full", className)} aria-busy="true">
+        <Skeleton className="h-2.5 w-full rounded-full" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return null;
+  }
+
+  if (showNoScheduleCta) {
+    return (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className={cn(
+          "h-8 w-full cursor-pointer gap-1.5 border-emerald-200/80 bg-emerald-50/50 text-emerald-800 hover:bg-emerald-100/80 dark:border-emerald-800/60 dark:bg-emerald-950/30 dark:text-emerald-200 dark:hover:bg-emerald-950/50",
+          className,
+        )}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          onNavigateToSchedule();
+        }}
+      >
+        <CalendarPlus className="size-3.5 shrink-0" aria-hidden />
+        Criar cronograma
+      </Button>
+    );
+  }
+
+  return (
+    <div className={cn("flex w-full flex-col items-center", className)}>
+      <ReadingProgressIndicator
+        progress={progress}
+        variant="card"
+        onNavigateToSchedule={onNavigateToSchedule}
+      />
+    </div>
+  );
+}
+
+export default CardReadingProgressIndicator;

--- a/src/modules/schedule/components/readingProgressIndicator/index.ts
+++ b/src/modules/schedule/components/readingProgressIndicator/index.ts
@@ -1,0 +1,9 @@
+export { default as CardReadingProgressIndicator } from "./cardReadingProgressIndicator";
+export { PageReadingProgressIndicator } from "./pageReadingProgressIndicator";
+export { ReadingProgressIndicator } from "./readingProgressIndicator";
+export type {
+  CardReadingProgressIndicatorProps,
+  PageReadingProgressIndicatorProps,
+  ReadingProgressIndicatorProps,
+  ReadingProgressIndicatorVariant,
+} from "./types/readingProgressIndicator.types";

--- a/src/modules/schedule/components/readingProgressIndicator/pageReadingProgressIndicator.tsx
+++ b/src/modules/schedule/components/readingProgressIndicator/pageReadingProgressIndicator.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useScheduleReadingProgress } from "../../hooks/useScheduleReadingProgress";
+import { ReadingProgressIndicator } from "./readingProgressIndicator";
+import type { PageReadingProgressIndicatorProps } from "./types/readingProgressIndicator.types";
+
+export function PageReadingProgressIndicator({
+  bookId,
+  schedule,
+  className,
+}: PageReadingProgressIndicatorProps) {
+  const { progress } = useScheduleReadingProgress(bookId, schedule);
+
+  return (
+    <ReadingProgressIndicator
+      progress={progress}
+      variant="page"
+      className={className}
+    />
+  );
+}
+
+export default PageReadingProgressIndicator;

--- a/src/modules/schedule/components/readingProgressIndicator/readingProgressIndicator.test.tsx
+++ b/src/modules/schedule/components/readingProgressIndicator/readingProgressIndicator.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ReadingProgressIndicator } from "./readingProgressIndicator";
+
+describe("ReadingProgressIndicator", () => {
+  it("retorna null quando progress é null (variant card)", () => {
+    const { container } = render(
+      <ReadingProgressIndicator progress={null} variant="card" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("retorna null quando progress é null (variant page)", () => {
+    const { container } = render(
+      <ReadingProgressIndicator progress={null} variant="page" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renderiza o variant card com barra e valor em porcentagem", () => {
+    render(
+      <ReadingProgressIndicator
+        progress={{ bookId: "b", total: 10, completed: 4, percentage: 40 }}
+        variant="card"
+      />,
+    );
+    expect(screen.getByRole("progressbar")).toBeTruthy();
+    expect(screen.getByText("40%")).toBeTruthy();
+    expect(screen.queryByText(/4\/10/)).toBeNull();
+  });
+
+  it("renderiza o variant page com cabeçalho e contagem em dias", () => {
+    render(
+      <ReadingProgressIndicator
+        progress={{ bookId: "b", total: 12, completed: 5, percentage: 42 }}
+        variant="page"
+      />,
+    );
+    expect(screen.getByText("Progresso de leitura")).toBeTruthy();
+    expect(screen.getByText(/42%/)).toBeTruthy();
+    expect(screen.getByText(/5 de 12 dias lidos/)).toBeTruthy();
+  });
+
+  it("usa singular quando há apenas um dia lido", () => {
+    render(
+      <ReadingProgressIndicator
+        progress={{ bookId: "b", total: 1, completed: 1, percentage: 100 }}
+        variant="page"
+      />,
+    );
+    expect(screen.getByText(/1 de 1 dia lido/)).toBeTruthy();
+  });
+
+  it("expõe label acessível com percentagem e total", () => {
+    render(
+      <ReadingProgressIndicator
+        progress={{ bookId: "b", total: 10, completed: 3, percentage: 30 }}
+        variant="card"
+      />,
+    );
+    const progressbar = screen.getByRole("progressbar");
+    expect(progressbar.getAttribute("aria-label")).toContain("3 de 10");
+    expect(progressbar.getAttribute("aria-label")).toContain("30%");
+    expect(progressbar.getAttribute("aria-valuenow")).toBe("30");
+    expect(progressbar.getAttribute("aria-valuemin")).toBe("0");
+    expect(progressbar.getAttribute("aria-valuemax")).toBe("100");
+  });
+
+  it("chama onNavigateToSchedule ao clicar no variant card", async () => {
+    const onNavigateToSchedule = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ReadingProgressIndicator
+        progress={{ bookId: "b", total: 10, completed: 3, percentage: 30 }}
+        variant="card"
+        onNavigateToSchedule={onNavigateToSchedule}
+      />,
+    );
+    await user.click(
+      screen.getByRole("button", { name: /Abrir cronograma — 3 de 10/ }),
+    );
+    expect(onNavigateToSchedule).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/schedule/components/readingProgressIndicator/readingProgressIndicator.tsx
+++ b/src/modules/schedule/components/readingProgressIndicator/readingProgressIndicator.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import type { KeyboardEvent } from "react";
+
+import { Progress } from "@/components/ui/progress";
+import { cn } from "@/lib/utils";
+import type { ReadingProgressIndicatorProps } from "./types/readingProgressIndicator.types";
+
+const readingProgressTrackClassName = cn(
+  "rounded-full bg-emerald-950/[0.08] shadow-inner shadow-emerald-950/[0.06] ring-1 ring-inset ring-emerald-950/[0.08]",
+  "dark:bg-emerald-400/[0.12] dark:shadow-emerald-950/20 dark:ring-emerald-400/20",
+);
+
+const readingProgressIndicatorClassName = cn(
+  "bg-linear-to-r from-emerald-500 via-teal-500 to-emerald-600",
+  "shadow-[0_0_10px_-2px_rgba(16,185,129,0.5)] dark:shadow-[0_0_14px_-2px_rgba(52,211,153,0.35)]",
+);
+
+function buildAriaLabel(completed: number, total: number, percentage: number) {
+  const unidade = total === 1 ? "leitura" : "leituras";
+  return `${completed} de ${total} ${unidade} concluídas (${percentage}%)`;
+}
+
+export function ReadingProgressIndicator({
+  progress,
+  variant,
+  className,
+  onNavigateToSchedule,
+}: ReadingProgressIndicatorProps) {
+  if (!progress) {
+    return null;
+  }
+
+  const { total, completed, percentage } = progress;
+  const ariaLabel = buildAriaLabel(completed, total, percentage);
+  const scheduleActionLabel = `Abrir cronograma — ${ariaLabel}`;
+
+  const handleScheduleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!onNavigateToSchedule) return;
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    onNavigateToSchedule();
+  };
+
+  if (variant === "card") {
+    const rowClassName = cn(
+      "flex w-full min-w-0 flex-col items-center gap-1.5",
+      onNavigateToSchedule &&
+        "cursor-pointer rounded-md outline-none transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-emerald-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+    );
+
+    const inner = (
+      <>
+        <Progress
+          value={percentage}
+          aria-label={onNavigateToSchedule ? undefined : ariaLabel}
+          aria-valuenow={percentage}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          className={cn(
+            "h-2.5 min-h-[10px] w-full min-w-0",
+            readingProgressTrackClassName,
+          )}
+          indicatorClassName={readingProgressIndicatorClassName}
+        />
+        <span
+          className="text-center text-xs font-semibold tabular-nums tracking-tight text-emerald-800 dark:text-emerald-300"
+          aria-hidden={!!onNavigateToSchedule}
+        >
+          {percentage}%
+        </span>
+      </>
+    );
+
+    if (onNavigateToSchedule) {
+      return (
+        <div
+          className={cn(rowClassName, className)}
+          role="button"
+          tabIndex={0}
+          aria-label={scheduleActionLabel}
+          onClick={onNavigateToSchedule}
+          onKeyDown={handleScheduleKeyDown}
+        >
+          <div className="flex w-full min-w-0 flex-col items-center gap-1.5" aria-hidden>
+            {inner}
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div
+        className={cn(rowClassName, className)}
+        role="group"
+        aria-label="Progresso de leitura"
+      >
+        {inner}
+      </div>
+    );
+  }
+
+  return (
+    <section
+      className={cn(
+        "flex w-full flex-col gap-3 rounded-2xl border border-emerald-900/10 bg-linear-to-br from-emerald-50/90 via-background to-teal-50/50 p-4 shadow-sm shadow-emerald-900/5",
+        "dark:border-emerald-400/15 dark:from-emerald-950/35 dark:via-card dark:to-teal-950/25 dark:shadow-black/20",
+        className,
+      )}
+      aria-label="Progresso de leitura"
+    >
+      <header className="flex items-baseline justify-between gap-3">
+        <span className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+          Progresso de leitura
+        </span>
+        <span
+          className="text-lg font-semibold tabular-nums tracking-tight text-emerald-800 dark:text-emerald-300"
+          aria-hidden
+        >
+          {percentage}%
+        </span>
+      </header>
+      <Progress
+        value={percentage}
+        aria-label={ariaLabel}
+        aria-valuenow={percentage}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        className={cn("h-2.5", readingProgressTrackClassName)}
+        indicatorClassName={readingProgressIndicatorClassName}
+      />
+      <p className="text-xs text-muted-foreground">
+        {completed} de {total} {total === 1 ? "dia lido" : "dias lidos"}
+      </p>
+    </section>
+  );
+}
+
+export default ReadingProgressIndicator;

--- a/src/modules/schedule/components/readingProgressIndicator/types/readingProgressIndicator.types.ts
+++ b/src/modules/schedule/components/readingProgressIndicator/types/readingProgressIndicator.types.ts
@@ -1,0 +1,23 @@
+import type { ScheduleDomain } from "../../../types/schedule.types";
+import type { ReadingProgressDomain } from "../../../types/readingProgress.types";
+
+export type ReadingProgressIndicatorVariant = "card" | "page";
+
+export type ReadingProgressIndicatorProps = {
+  progress: ReadingProgressDomain | null;
+  variant: ReadingProgressIndicatorVariant;
+  className?: string;
+  onNavigateToSchedule?: () => void;
+};
+
+export type CardReadingProgressIndicatorProps = {
+  bookId: string | undefined;
+  onNavigateToSchedule: () => void;
+  className?: string;
+};
+
+export type PageReadingProgressIndicatorProps = {
+  bookId: string;
+  schedule: readonly ScheduleDomain[] | undefined;
+  className?: string;
+};

--- a/src/modules/schedule/context/scheduleProgressBatchContext.tsx
+++ b/src/modules/schedule/context/scheduleProgressBatchContext.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { createContext } from "react";
+import type { ReadingProgressByBookId } from "../types/readingProgress.types";
+
+export type ScheduleProgressBatchContextValue = {
+  readingBookIds: readonly string[];
+  progressByBookId: ReadingProgressByBookId;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+export const ScheduleProgressBatchContext = createContext<
+  ScheduleProgressBatchContextValue | undefined
+>(undefined);

--- a/src/modules/schedule/hooks/index.ts
+++ b/src/modules/schedule/hooks/index.ts
@@ -1,3 +1,7 @@
+export { useBookCardScheduleProgress } from "./useBookCardScheduleProgress";
 export { useOptimisticScheduleDelete } from "./useOptimisticScheduleDelete";
 export { useOptimisticScheduleReadToggle } from "./useOptimisticScheduleReadToggle";
+export { useReadingProgress } from "./useReadingProgress";
+export { useReadingProgressMany } from "./useReadingProgressMany";
 export { useSchedule } from "./useSchedule";
+export { useScheduleReadingProgress } from "./useScheduleReadingProgress";

--- a/src/modules/schedule/hooks/useBookCardScheduleProgress.spec.ts
+++ b/src/modules/schedule/hooks/useBookCardScheduleProgress.spec.ts
@@ -1,0 +1,117 @@
+import { renderHook } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ScheduleProgressBatchContext } from "../context/scheduleProgressBatchContext";
+import type { ReadingProgressDomain } from "../types/readingProgress.types";
+import { useBookCardScheduleProgress } from "./useBookCardScheduleProgress";
+
+const mockUseReadingProgressMany = vi.hoisted(() => vi.fn());
+
+vi.mock("./useReadingProgressMany", () => ({
+  useReadingProgressMany: mockUseReadingProgressMany,
+}));
+
+function makeBatch(overrides: {
+  progressByBookId?: Map<string, ReadingProgressDomain>;
+  isLoading?: boolean;
+  isError?: boolean;
+}) {
+  return {
+    readingBookIds: ["book-1"] as const,
+    progressByBookId: overrides.progressByBookId ?? new Map(),
+    isLoading: overrides.isLoading ?? false,
+    isError: overrides.isError ?? false,
+  };
+}
+
+describe("useBookCardScheduleProgress", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseReadingProgressMany.mockReturnValue({
+      progressByBookId: new Map(),
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  it("com batch da Home usa o mapa do contexto e ignora o fallback", () => {
+    const domain: ReadingProgressDomain = {
+      bookId: "book-1",
+      total: 10,
+      completed: 3,
+      percentage: 30,
+    };
+    const batch = makeBatch({
+      progressByBookId: new Map([["book-1", domain]]),
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        ScheduleProgressBatchContext.Provider,
+        { value: batch },
+        children,
+      );
+
+    const { result } = renderHook(() => useBookCardScheduleProgress("book-1"), {
+      wrapper,
+    });
+
+    expect(mockUseReadingProgressMany).toHaveBeenCalledWith([]);
+    expect(result.current.progress).toEqual(domain);
+    expect(result.current.showNoScheduleCta).toBe(false);
+  });
+
+  it("com batch e sem linha do livro indica CTA de criar cronograma", () => {
+    const batch = makeBatch({ progressByBookId: new Map() });
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        ScheduleProgressBatchContext.Provider,
+        { value: batch },
+        children,
+      );
+
+    const { result } = renderHook(() => useBookCardScheduleProgress("book-1"), {
+      wrapper,
+    });
+
+    expect(result.current.progress).toBeNull();
+    expect(result.current.showNoScheduleCta).toBe(true);
+  });
+
+  it("enquanto carrega no batch não mostra CTA", () => {
+    const batch = makeBatch({ isLoading: true });
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        ScheduleProgressBatchContext.Provider,
+        { value: batch },
+        children,
+      );
+
+    const { result } = renderHook(() => useBookCardScheduleProgress("book-1"), {
+      wrapper,
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.showNoScheduleCta).toBe(false);
+  });
+
+  it("sem Provider usa useReadingProgressMany com o único bookId", () => {
+    const domain: ReadingProgressDomain = {
+      bookId: "book-1",
+      total: 4,
+      completed: 4,
+      percentage: 100,
+    };
+    mockUseReadingProgressMany.mockReturnValue({
+      progressByBookId: new Map([["book-1", domain]]),
+      isLoading: false,
+      isError: false,
+    });
+
+    const { result } = renderHook(() => useBookCardScheduleProgress("book-1"));
+
+    expect(mockUseReadingProgressMany).toHaveBeenCalledWith(["book-1"]);
+    expect(result.current.progress).toEqual(domain);
+    expect(result.current.showNoScheduleCta).toBe(false);
+  });
+});

--- a/src/modules/schedule/hooks/useBookCardScheduleProgress.ts
+++ b/src/modules/schedule/hooks/useBookCardScheduleProgress.ts
@@ -1,0 +1,46 @@
+import { useContext, useMemo } from "react";
+import { ScheduleProgressBatchContext } from "../context/scheduleProgressBatchContext";
+import { useReadingProgressMany } from "./useReadingProgressMany";
+
+export function useBookCardScheduleProgress(bookId: string | undefined) {
+  const batch = useContext(ScheduleProgressBatchContext);
+
+  const fallbackIds = useMemo(() => {
+    if (batch !== undefined || !bookId) {
+      return [] as string[];
+    }
+    return [bookId];
+  }, [batch, bookId]);
+
+  const fallback = useReadingProgressMany(fallbackIds);
+
+  return useMemo(() => {
+    const progressByBookId =
+      batch !== undefined ? batch.progressByBookId : fallback.progressByBookId;
+    const isLoading =
+      batch !== undefined ? batch.isLoading : fallback.isLoading;
+    const isError = batch !== undefined ? batch.isError : fallback.isError;
+
+    const progress =
+      bookId !== undefined && bookId !== ""
+        ? progressByBookId.get(bookId) ?? null
+        : null;
+
+    return {
+      progress,
+      isLoading,
+      isError,
+      showNoScheduleCta:
+        !!bookId &&
+        !isLoading &&
+        !isError &&
+        progress === null,
+    };
+  }, [
+    batch,
+    bookId,
+    fallback.isError,
+    fallback.isLoading,
+    fallback.progressByBookId,
+  ]);
+}

--- a/src/modules/schedule/hooks/useOptimisticScheduleReadToggle.spec.ts
+++ b/src/modules/schedule/hooks/useOptimisticScheduleReadToggle.spec.ts
@@ -148,4 +148,38 @@ describe("useOptimisticScheduleReadToggle", () => {
       });
     });
   });
+
+  it("invalida também o cache aggregated many de progresso de leitura", async () => {
+    const { queryClient, wrapper, invalidateQueries } = makeTestContext();
+    queryClient.setQueryData(scheduleKey, [
+      {
+        id: "row-1",
+        owner: userId,
+        date: "2024-01-01",
+        chapters: "1",
+        completed: false,
+      },
+    ]);
+
+    const { result } = renderHook(
+      () => useOptimisticScheduleReadToggle(bookId, userId),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.updateRead("row-1", true);
+    });
+
+    await waitFor(() => {
+      const predicateCalls = invalidateQueries.mock.calls.filter(
+        ([arg]) => typeof (arg as { predicate?: unknown }).predicate === "function",
+      );
+      expect(predicateCalls.length).toBeGreaterThanOrEqual(1);
+      const predicate = (predicateCalls[0][0] as {
+        predicate: (q: { queryKey: unknown }) => boolean;
+      }).predicate;
+      expect(predicate({ queryKey: ["schedule", "progress", "many", "x", userId] })).toBe(true);
+      expect(predicate({ queryKey: ["schedule", bookId, userId] })).toBe(false);
+    });
+  });
 });

--- a/src/modules/schedule/hooks/useOptimisticScheduleReadToggle.ts
+++ b/src/modules/schedule/hooks/useOptimisticScheduleReadToggle.ts
@@ -4,6 +4,7 @@ import {
   ScheduleReadToggleMutationContext,
   ScheduleReadToggleVariables,
 } from "@/modules/schedule/types/scheduleReadToggle.types";
+import { invalidateReadingProgressManyCaches } from "@/modules/schedule/utils/readingProgressQueryKey";
 import {
   getScheduleBookQueryFilterKey,
   getScheduleQueryKey,
@@ -55,9 +56,12 @@ export function useOptimisticScheduleReadToggle(
       }
     },
     onSettled: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: getScheduleBookQueryFilterKey(bookId),
-      });
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: getScheduleBookQueryFilterKey(bookId),
+        }),
+        invalidateReadingProgressManyCaches(queryClient),
+      ]);
     },
   });
 

--- a/src/modules/schedule/hooks/useReadingProgress.spec.ts
+++ b/src/modules/schedule/hooks/useReadingProgress.spec.ts
@@ -1,0 +1,86 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockUseUserStore } = vi.hoisted(() => ({
+  mockUseUserStore: vi.fn(),
+}));
+
+vi.mock("@/stores/userStore", () => ({
+  useUserStore: (selector: (state: { user?: { id?: string } }) => unknown) =>
+    mockUseUserStore(selector),
+}));
+
+import { getReadingProgressManyQueryKey } from "@/modules/schedule/utils/readingProgressQueryKey";
+import type { ReadingProgressDomain } from "@/modules/schedule/types/readingProgress.types";
+import { useReadingProgress } from "./useReadingProgress";
+
+function makeWrapper(seedCache?: (qc: QueryClient) => void) {
+  const queryClient = new QueryClient();
+  seedCache?.(queryClient);
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { queryClient, wrapper };
+}
+
+describe("useReadingProgress", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseUserStore.mockImplementation((selector) =>
+      selector({ user: { id: "user-1" } }),
+    );
+  });
+
+  it("retorna null quando bookId está ausente", () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useReadingProgress(undefined), { wrapper });
+    expect(result.current.progress).toBeNull();
+  });
+
+  it("retorna null quando userId não está disponível", () => {
+    mockUseUserStore.mockImplementation((selector) =>
+      selector({ user: undefined }),
+    );
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useReadingProgress("book-1"), { wrapper });
+    expect(result.current.progress).toBeNull();
+  });
+
+  it("retorna null quando o cache many ainda não foi populado", () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useReadingProgress("book-1"), { wrapper });
+    expect(result.current.progress).toBeNull();
+  });
+
+  it("encontra o progresso no cache many populado com a key correta", () => {
+    const cached: ReadingProgressDomain[] = [
+      { bookId: "book-1", total: 10, completed: 4, percentage: 40 },
+      { bookId: "book-2", total: 5, completed: 5, percentage: 100 },
+    ];
+    const { wrapper } = makeWrapper((qc) => {
+      qc.setQueryData(
+        getReadingProgressManyQueryKey(["book-1", "book-2"], "user-1"),
+        cached,
+      );
+    });
+
+    const { result } = renderHook(() => useReadingProgress("book-1"), { wrapper });
+    expect(result.current.progress).toEqual(cached[0]);
+  });
+
+  it("ignora caches de outro usuário (RN44)", () => {
+    const cached: ReadingProgressDomain[] = [
+      { bookId: "book-1", total: 10, completed: 4, percentage: 40 },
+    ];
+    const { wrapper } = makeWrapper((qc) => {
+      qc.setQueryData(
+        getReadingProgressManyQueryKey(["book-1"], "outro-usuario"),
+        cached,
+      );
+    });
+
+    const { result } = renderHook(() => useReadingProgress("book-1"), { wrapper });
+    expect(result.current.progress).toBeNull();
+  });
+});

--- a/src/modules/schedule/hooks/useReadingProgress.ts
+++ b/src/modules/schedule/hooks/useReadingProgress.ts
@@ -1,0 +1,38 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { useUserStore } from "@/stores/userStore";
+import type { ReadingProgressDomain } from "../types/readingProgress.types";
+
+export function useReadingProgress(bookId: string | undefined) {
+  const queryClient = useQueryClient();
+  const userId = useUserStore((state) => state.user?.id);
+
+  const progress = useMemo<ReadingProgressDomain | null>(() => {
+    if (!bookId || !userId) {
+      return null;
+    }
+
+    const caches = queryClient.getQueriesData<ReadingProgressDomain[]>({
+      predicate: (query) => {
+        const key = query.queryKey;
+        return (
+          Array.isArray(key) &&
+          key[0] === "schedule" &&
+          key[1] === "progress" &&
+          key[2] === "many" &&
+          key[4] === userId
+        );
+      },
+    });
+
+    for (const [, data] of caches) {
+      if (!Array.isArray(data)) continue;
+      const found = data.find((row) => row.bookId === bookId);
+      if (found) return found;
+    }
+
+    return null;
+  }, [queryClient, bookId, userId]);
+
+  return useMemo(() => ({ progress }), [progress]);
+}

--- a/src/modules/schedule/hooks/useReadingProgressMany.spec.ts
+++ b/src/modules/schedule/hooks/useReadingProgressMany.spec.ts
@@ -1,0 +1,120 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetMany, mockUseUserStore, mockUseIsLoggedIn } = vi.hoisted(() => ({
+  mockGetMany: vi.fn(),
+  mockUseUserStore: vi.fn(),
+  mockUseIsLoggedIn: vi.fn(),
+}));
+
+vi.mock("@/modules/schedule/services/readingProgress.service", () => ({
+  ReadingProgressService: class {
+    getMany = mockGetMany;
+  },
+}));
+
+vi.mock("@/stores/userStore", () => ({
+  useUserStore: (selector: (state: { user?: { id?: string } }) => unknown) =>
+    mockUseUserStore(selector),
+}));
+
+vi.mock("@/stores/hooks/useAuth", () => ({
+  useIsLoggedIn: () => mockUseIsLoggedIn(),
+}));
+
+import { useReadingProgressMany } from "./useReadingProgressMany";
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { queryClient, wrapper };
+}
+
+describe("useReadingProgressMany", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseUserStore.mockImplementation((selector) =>
+      selector({ user: { id: "user-1" } }),
+    );
+    mockUseIsLoggedIn.mockReturnValue(true);
+  });
+
+  it("não dispara fetch quando o usuário não está logado", () => {
+    mockUseIsLoggedIn.mockReturnValue(false);
+    const { wrapper } = makeWrapper();
+    renderHook(() => useReadingProgressMany(["a", "b"]), { wrapper });
+    expect(mockGetMany).not.toHaveBeenCalled();
+  });
+
+  it("não dispara fetch quando bookIds está vazio", () => {
+    const { wrapper } = makeWrapper();
+    renderHook(() => useReadingProgressMany([]), { wrapper });
+    expect(mockGetMany).not.toHaveBeenCalled();
+  });
+
+  it("dispara fetch ordenando os bookIds para garantir cache key estável", async () => {
+    mockGetMany.mockResolvedValueOnce([]);
+    const { wrapper } = makeWrapper();
+    renderHook(() => useReadingProgressMany(["b", "a", "c"]), { wrapper });
+
+    await waitFor(() => {
+      expect(mockGetMany).toHaveBeenCalledTimes(1);
+      expect(mockGetMany).toHaveBeenCalledWith(["a", "b", "c"]);
+    });
+  });
+
+  it("transforma o payload de persistência em mapa por bookId", async () => {
+    mockGetMany.mockResolvedValueOnce([
+      { book_id: "a", total: 10, completed: 4 },
+      { book_id: "b", total: 5, completed: 5 },
+    ]);
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useReadingProgressMany(["a", "b"]),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.progressByBookId.size).toBe(2);
+    });
+
+    expect(result.current.progressByBookId.get("a")).toEqual({
+      bookId: "a",
+      total: 10,
+      completed: 4,
+      percentage: 40,
+    });
+    expect(result.current.progressByBookId.get("b")).toEqual({
+      bookId: "b",
+      total: 5,
+      completed: 5,
+      percentage: 100,
+    });
+  });
+
+  it("omite entradas com total inválido (RNxx-03)", async () => {
+    mockGetMany.mockResolvedValueOnce([
+      { book_id: "a", total: 0, completed: 0 },
+      { book_id: "b", total: 3, completed: 1 },
+    ]);
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useReadingProgressMany(["a", "b"]),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.progressByBookId.size).toBe(1);
+    });
+    expect(result.current.progressByBookId.has("a")).toBe(false);
+    expect(result.current.progressByBookId.has("b")).toBe(true);
+  });
+});

--- a/src/modules/schedule/hooks/useReadingProgressMany.ts
+++ b/src/modules/schedule/hooks/useReadingProgressMany.ts
@@ -1,0 +1,83 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { useIsLoggedIn } from "@/stores/hooks/useAuth";
+import { useUserStore } from "@/stores/userStore";
+import { ReadingProgressService } from "../services/readingProgress.service";
+import type {
+  ReadingProgressByBookId,
+  ReadingProgressDomain,
+  ReadingProgressPersistence,
+} from "../types/readingProgress.types";
+import { computeReadingProgress } from "../utils/computeReadingProgress";
+import { getReadingProgressManyQueryKey } from "../utils/readingProgressQueryKey";
+
+const service = new ReadingProgressService();
+
+const STALE_TIME = 1000 * 60 * 5;
+const GC_TIME = 1000 * 60 * 10;
+
+function toDomainList(
+  rows: readonly ReadingProgressPersistence[],
+): ReadingProgressDomain[] {
+  const domains: ReadingProgressDomain[] = [];
+  for (const row of rows) {
+    const domain = computeReadingProgress(row.book_id, row.total, row.completed);
+    if (domain) {
+      domains.push(domain);
+    }
+  }
+  return domains;
+}
+
+function toDomainMap(
+  rows: readonly ReadingProgressDomain[],
+): ReadingProgressByBookId {
+  const map = new Map<string, ReadingProgressDomain>();
+  for (const row of rows) {
+    map.set(row.bookId, row);
+  }
+  return map;
+}
+
+export function useReadingProgressMany(bookIds: readonly string[]) {
+  const isLoggedIn = useIsLoggedIn();
+  const userId = useUserStore((state) => state.user?.id);
+
+  const sortedBookIds = useMemo(
+    () => [...bookIds].sort(),
+    [bookIds],
+  );
+
+  const queryKey = useMemo(
+    () => getReadingProgressManyQueryKey(sortedBookIds, userId),
+    [sortedBookIds, userId],
+  );
+
+  const enabled = isLoggedIn && !!userId && sortedBookIds.length > 0;
+
+  const { data, isLoading, isError } = useQuery<ReadingProgressDomain[]>({
+    queryKey,
+    queryFn: async () => {
+      const persistence = await service.getMany(sortedBookIds);
+      return toDomainList(persistence);
+    },
+    enabled,
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+    refetchOnMount: false,
+  });
+
+  const progressByBookId = useMemo<ReadingProgressByBookId>(
+    () => (Array.isArray(data) ? toDomainMap(data) : new Map()),
+    [data],
+  );
+
+  return useMemo(
+    () => ({
+      progressByBookId,
+      isLoading: enabled && isLoading,
+      isError,
+    }),
+    [progressByBookId, enabled, isLoading, isError],
+  );
+}

--- a/src/modules/schedule/hooks/useScheduleReadingProgress.spec.ts
+++ b/src/modules/schedule/hooks/useScheduleReadingProgress.spec.ts
@@ -1,0 +1,49 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { ScheduleDomain } from "@/modules/schedule/types/schedule.types";
+import { useScheduleReadingProgress } from "./useScheduleReadingProgress";
+
+describe("useScheduleReadingProgress", () => {
+  it("retorna null quando o cronograma está indefinido", () => {
+    const { result } = renderHook(() =>
+      useScheduleReadingProgress("book-1", undefined),
+    );
+    expect(result.current.progress).toBeNull();
+  });
+
+  it("retorna null quando o cronograma está vazio", () => {
+    const { result } = renderHook(() =>
+      useScheduleReadingProgress("book-1", []),
+    );
+    expect(result.current.progress).toBeNull();
+  });
+
+  it("calcula progresso derivado das linhas marcadas como lidas", () => {
+    const schedule: ScheduleDomain[] = [
+      { owner: "u1", date: "2025-01-01", chapters: "1", completed: true },
+      { owner: "u1", date: "2025-01-02", chapters: "2", completed: false },
+      { owner: "u1", date: "2025-01-03", chapters: "3", completed: true },
+      { owner: "u1", date: "2025-01-04", chapters: "4", completed: false },
+    ];
+    const { result } = renderHook(() =>
+      useScheduleReadingProgress("book-1", schedule),
+    );
+    expect(result.current.progress).toEqual({
+      bookId: "book-1",
+      total: 4,
+      completed: 2,
+      percentage: 50,
+    });
+  });
+
+  it("retorna 100% quando todas as linhas estão completas", () => {
+    const schedule: ScheduleDomain[] = [
+      { owner: "u1", date: "2025-01-01", chapters: "1", completed: true },
+      { owner: "u1", date: "2025-01-02", chapters: "2", completed: true },
+    ];
+    const { result } = renderHook(() =>
+      useScheduleReadingProgress("book-1", schedule),
+    );
+    expect(result.current.progress?.percentage).toBe(100);
+  });
+});

--- a/src/modules/schedule/hooks/useScheduleReadingProgress.ts
+++ b/src/modules/schedule/hooks/useScheduleReadingProgress.ts
@@ -1,0 +1,15 @@
+import { useMemo } from "react";
+import type { ScheduleDomain } from "../types/schedule.types";
+import { computeReadingProgressFromSchedule } from "../utils/computeReadingProgress";
+
+export function useScheduleReadingProgress(
+  bookId: string,
+  schedule: readonly ScheduleDomain[] | undefined,
+) {
+  const progress = useMemo(
+    () => computeReadingProgressFromSchedule(bookId, schedule),
+    [bookId, schedule],
+  );
+
+  return useMemo(() => ({ progress }), [progress]);
+}

--- a/src/modules/schedule/index.tsx
+++ b/src/modules/schedule/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CreateScheduleForm } from "./components/createScheduleForm";
+import { PageReadingProgressIndicator } from "./components/readingProgressIndicator";
 import { useSchedule } from "./hooks";
 import { ClientScheduleProps } from "./types/schedule.types";
 import { ScheduleTable } from "./components/scheduleTable";
@@ -60,18 +61,21 @@ export default function ClientSchedule({ id, title }: ClientScheduleProps) {
       </header>
 
       {shouldDisplayScheduleTable ? (
-        <ScheduleTable
-          schedule={schedule}
-          updateIsCompleted={updateIsCompleted}
-          deleteSchedule={async (scheduleBookId: string) =>
-            deleteSchedule({
-              id: scheduleBookId,
-            })
-          }
-          bookId={id}
-          isReadTogglePending={isReadTogglePending}
-          pendingScheduleId={pendingScheduleId}
-        />
+        <>
+          <PageReadingProgressIndicator bookId={id} schedule={schedule} />
+          <ScheduleTable
+            schedule={schedule}
+            updateIsCompleted={updateIsCompleted}
+            deleteSchedule={async (scheduleBookId: string) =>
+              deleteSchedule({
+                id: scheduleBookId,
+              })
+            }
+            bookId={id}
+            isReadTogglePending={isReadTogglePending}
+            pendingScheduleId={pendingScheduleId}
+          />
+        </>
       ) : (
         <CreateScheduleForm id={id} title={title} />
       )}

--- a/src/modules/schedule/services/readingProgress.service.test.ts
+++ b/src/modules/schedule/services/readingProgress.service.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockApiJson } = vi.hoisted(() => ({
+  mockApiJson: vi.fn(),
+}));
+
+vi.mock("@/lib/api/clientJsonFetch", () => ({
+  apiJson: mockApiJson,
+}));
+
+vi.mock("@/services/errors/error", () => ({
+  ErrorHandler: {
+    normalize: (error: unknown) =>
+      error instanceof Error ? error : new Error(String(error)),
+    log: vi.fn(),
+  },
+}));
+
+import { ReadingProgressService } from "./readingProgress.service";
+
+describe("ReadingProgressService", () => {
+  let service: ReadingProgressService;
+
+  beforeEach(() => {
+    service = new ReadingProgressService();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getMany", () => {
+    it("curto-circuita devolvendo [] sem disparar HTTP quando bookIds está vazio", async () => {
+      const result = await service.getMany([]);
+      expect(result).toEqual([]);
+      expect(mockApiJson).not.toHaveBeenCalled();
+    });
+
+    it("monta a URL com CSV dos bookIds e usa método GET", async () => {
+      mockApiJson.mockResolvedValueOnce([]);
+
+      await service.getMany(["a", "b", "c"]);
+
+      expect(mockApiJson).toHaveBeenCalledTimes(1);
+      const [path, init] = mockApiJson.mock.calls[0];
+      expect(path).toBe("/api/schedule/progress?bookIds=a%2Cb%2Cc");
+      expect(init).toEqual({ method: "GET" });
+    });
+
+    it("repassa o payload de progresso recebido da API", async () => {
+      const payload = [
+        { book_id: "a", total: 10, completed: 4 },
+        { book_id: "b", total: 5, completed: 5 },
+      ];
+      mockApiJson.mockResolvedValueOnce(payload);
+
+      const result = await service.getMany(["a", "b"]);
+      expect(result).toBe(payload);
+    });
+
+    it("propaga erros normalizados quando a API falha", async () => {
+      mockApiJson.mockRejectedValueOnce(new Error("network down"));
+
+      await expect(service.getMany(["a"])).rejects.toThrow("network down");
+    });
+  });
+});

--- a/src/modules/schedule/services/readingProgress.service.ts
+++ b/src/modules/schedule/services/readingProgress.service.ts
@@ -1,0 +1,29 @@
+import { apiJson } from "@/lib/api/clientJsonFetch";
+import { ErrorHandler } from "@/services/errors/error";
+import type { ReadingProgressPersistence } from "../types/readingProgress.types";
+
+export class ReadingProgressService {
+  async getMany(
+    bookIds: readonly string[],
+  ): Promise<ReadingProgressPersistence[]> {
+    if (bookIds.length === 0) {
+      return [];
+    }
+
+    try {
+      const search = new URLSearchParams({ bookIds: bookIds.join(",") });
+      return await apiJson<ReadingProgressPersistence[]>(
+        `/api/schedule/progress?${search.toString()}`,
+        { method: "GET" },
+      );
+    } catch (error) {
+      const normalizedError = ErrorHandler.normalize(error, {
+        service: "ReadingProgressService",
+        method: "getMany",
+        bookIds,
+      });
+      ErrorHandler.log(normalizedError);
+      throw normalizedError;
+    }
+  }
+}

--- a/src/modules/schedule/types/readingProgress.types.ts
+++ b/src/modules/schedule/types/readingProgress.types.ts
@@ -1,0 +1,14 @@
+export type ReadingProgressPersistence = {
+  book_id: string;
+  total: number;
+  completed: number;
+};
+
+export type ReadingProgressDomain = {
+  bookId: string;
+  total: number;
+  completed: number;
+  percentage: number;
+};
+
+export type ReadingProgressByBookId = Map<string, ReadingProgressDomain>;

--- a/src/modules/schedule/utils/computeReadingProgress.test.ts
+++ b/src/modules/schedule/utils/computeReadingProgress.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeReadingProgress,
+  computeReadingProgressFromSchedule,
+} from "./computeReadingProgress";
+
+describe("computeReadingProgress", () => {
+  it("retorna null quando total é zero", () => {
+    expect(computeReadingProgress("book-1", 0, 0)).toBeNull();
+  });
+
+  it("retorna null quando total é negativo", () => {
+    expect(computeReadingProgress("book-1", -1, 0)).toBeNull();
+  });
+
+  it("retorna null quando total não é finito", () => {
+    expect(computeReadingProgress("book-1", Number.NaN, 0)).toBeNull();
+    expect(computeReadingProgress("book-1", Number.POSITIVE_INFINITY, 0)).toBeNull();
+  });
+
+  it("calcula 0% quando nenhum capítulo foi lido", () => {
+    expect(computeReadingProgress("book-1", 10, 0)).toEqual({
+      bookId: "book-1",
+      total: 10,
+      completed: 0,
+      percentage: 0,
+    });
+  });
+
+  it("calcula 100% quando todos os capítulos foram lidos", () => {
+    expect(computeReadingProgress("book-1", 10, 10)).toEqual({
+      bookId: "book-1",
+      total: 10,
+      completed: 10,
+      percentage: 100,
+    });
+  });
+
+  it("arredonda percentuais não inteiros", () => {
+    expect(computeReadingProgress("book-1", 7, 3)).toEqual({
+      bookId: "book-1",
+      total: 7,
+      completed: 3,
+      percentage: 43,
+    });
+    expect(computeReadingProgress("book-1", 7, 5)).toEqual({
+      bookId: "book-1",
+      total: 7,
+      completed: 5,
+      percentage: 71,
+    });
+  });
+
+  it("trata completed maior que total como total (clamp)", () => {
+    expect(computeReadingProgress("book-1", 5, 99)).toEqual({
+      bookId: "book-1",
+      total: 5,
+      completed: 5,
+      percentage: 100,
+    });
+  });
+
+  it("trata completed negativo como zero", () => {
+    expect(computeReadingProgress("book-1", 5, -10)).toEqual({
+      bookId: "book-1",
+      total: 5,
+      completed: 0,
+      percentage: 0,
+    });
+  });
+
+  it("trata completed não finito como zero", () => {
+    expect(computeReadingProgress("book-1", 5, Number.NaN)).toEqual({
+      bookId: "book-1",
+      total: 5,
+      completed: 0,
+      percentage: 0,
+    });
+  });
+});
+
+describe("computeReadingProgressFromSchedule", () => {
+  it("retorna null para cronograma vazio", () => {
+    expect(computeReadingProgressFromSchedule("book-1", [])).toBeNull();
+  });
+
+  it("retorna null para cronograma indefinido", () => {
+    expect(computeReadingProgressFromSchedule("book-1", undefined)).toBeNull();
+    expect(computeReadingProgressFromSchedule("book-1", null)).toBeNull();
+  });
+
+  it("conta corretamente linhas completas", () => {
+    const schedule = [
+      { completed: true },
+      { completed: false },
+      { completed: true },
+      { completed: false },
+    ];
+    expect(computeReadingProgressFromSchedule("book-1", schedule)).toEqual({
+      bookId: "book-1",
+      total: 4,
+      completed: 2,
+      percentage: 50,
+    });
+  });
+
+  it("retorna 100% quando todas as linhas estão completas", () => {
+    const schedule = [{ completed: true }, { completed: true }];
+    expect(computeReadingProgressFromSchedule("book-1", schedule)).toEqual({
+      bookId: "book-1",
+      total: 2,
+      completed: 2,
+      percentage: 100,
+    });
+  });
+});

--- a/src/modules/schedule/utils/computeReadingProgress.ts
+++ b/src/modules/schedule/utils/computeReadingProgress.ts
@@ -1,0 +1,41 @@
+import type { ReadingProgressDomain } from "../types/readingProgress.types";
+
+export function computeReadingProgress(
+  bookId: string,
+  total: number,
+  completed: number,
+): ReadingProgressDomain | null {
+  if (!Number.isFinite(total) || total <= 0) {
+    return null;
+  }
+
+  const safeCompleted = Math.max(
+    0,
+    Math.min(Number.isFinite(completed) ? completed : 0, total),
+  );
+
+  const percentage = Math.round((safeCompleted / total) * 100);
+
+  return {
+    bookId,
+    total,
+    completed: safeCompleted,
+    percentage,
+  };
+}
+
+export function computeReadingProgressFromSchedule<
+  T extends { completed: boolean },
+>(bookId: string, schedule: readonly T[] | undefined | null): ReadingProgressDomain | null {
+  if (!schedule || schedule.length === 0) {
+    return null;
+  }
+
+  const total = schedule.length;
+  const completed = schedule.reduce(
+    (acc, row) => (row.completed ? acc + 1 : acc),
+    0,
+  );
+
+  return computeReadingProgress(bookId, total, completed);
+}

--- a/src/modules/schedule/utils/readingProgressQueryKey.test.ts
+++ b/src/modules/schedule/utils/readingProgressQueryKey.test.ts
@@ -1,0 +1,75 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import {
+  getReadingProgressManyQueryKey,
+  getReadingProgressSingleQueryKey,
+  invalidateReadingProgressManyCaches,
+} from "./readingProgressQueryKey";
+
+describe("getReadingProgressSingleQueryKey", () => {
+  it("inclui livro e usuário sob o prefixo schedule", () => {
+    expect(getReadingProgressSingleQueryKey("book-1", "user-1")).toEqual([
+      "schedule",
+      "book-1",
+      "progress",
+      "user-1",
+    ]);
+  });
+
+  it("aceita userId indefinido", () => {
+    expect(getReadingProgressSingleQueryKey("book-1", undefined)).toEqual([
+      "schedule",
+      "book-1",
+      "progress",
+      undefined,
+    ]);
+  });
+});
+
+describe("getReadingProgressManyQueryKey", () => {
+  it("normaliza a ordem dos bookIds para garantir cache key estável", () => {
+    const a = getReadingProgressManyQueryKey(["b", "a", "c"], "user-1");
+    const b = getReadingProgressManyQueryKey(["c", "a", "b"], "user-1");
+    expect(a).toEqual(b);
+  });
+
+  it("usa prefixo schedule/progress/many", () => {
+    const key = getReadingProgressManyQueryKey(["a", "b"], "user-1");
+    expect(key[0]).toBe("schedule");
+    expect(key[1]).toBe("progress");
+    expect(key[2]).toBe("many");
+    expect(key[3]).toBe("a|b");
+    expect(key[4]).toBe("user-1");
+  });
+
+  it("trata lista vazia gerando hash vazio", () => {
+    const key = getReadingProgressManyQueryKey([], "user-1");
+    expect(key[3]).toBe("");
+  });
+
+  it("não muta o array de entrada", () => {
+    const input = ["c", "a", "b"];
+    const snapshot = [...input];
+    getReadingProgressManyQueryKey(input, "user-1");
+    expect(input).toEqual(snapshot);
+  });
+});
+
+describe("invalidateReadingProgressManyCaches", () => {
+  it("invalida queries que casam o predicado do cache many", async () => {
+    const queryClient = new QueryClient();
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+
+    await invalidateReadingProgressManyCaches(queryClient);
+
+    expect(invalidateQueries).toHaveBeenCalledTimes(1);
+    const arg = invalidateQueries.mock.calls[0][0] as {
+      predicate: (q: { queryKey: unknown }) => boolean;
+    };
+
+    expect(arg.predicate({ queryKey: ["schedule", "progress", "many", "a|b", "u"] })).toBe(true);
+    expect(arg.predicate({ queryKey: ["schedule", "book-1", "u"] })).toBe(false);
+    expect(arg.predicate({ queryKey: ["books", "list"] })).toBe(false);
+    expect(arg.predicate({ queryKey: "not-array" })).toBe(false);
+  });
+});

--- a/src/modules/schedule/utils/readingProgressQueryKey.ts
+++ b/src/modules/schedule/utils/readingProgressQueryKey.ts
@@ -1,0 +1,38 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+export function getReadingProgressSingleQueryKey(
+  bookId: string,
+  userId: string | undefined,
+) {
+  return ["schedule", bookId, "progress", userId] as const;
+}
+
+export function getReadingProgressManyQueryKey(
+  bookIds: readonly string[],
+  userId: string | undefined,
+) {
+  const sortedIds = [...bookIds].sort();
+  return [
+    "schedule",
+    "progress",
+    "many",
+    sortedIds.join("|"),
+    userId,
+  ] as const;
+}
+
+export async function invalidateReadingProgressManyCaches(
+  queryClient: QueryClient,
+) {
+  await queryClient.invalidateQueries({
+    predicate: (query) => {
+      const key = query.queryKey;
+      return (
+        Array.isArray(key) &&
+        key[0] === "schedule" &&
+        key[1] === "progress" &&
+        key[2] === "many"
+      );
+    },
+  });
+}

--- a/supabase/migrations/20260517160000_schedule_progress_rpc.sql
+++ b/supabase/migrations/20260517160000_schedule_progress_rpc.sql
@@ -1,0 +1,48 @@
+-- =============================================================================
+-- Feature 001 — Progresso de leitura baseado no cronograma
+-- Spec: .sdd/specs/001-progresso-leitura-cronograma/
+-- =============================================================================
+--
+-- Cria a RPC `get_schedule_progress_for_books(book_ids uuid[])` que agrega
+-- (total, completed) por book_id para o usuário autenticado (auth.uid()),
+-- alinhada a RN44 (cronograma isolado por owner).
+--
+-- A RPC é SECURITY INVOKER + WHERE explícito `owner = auth.uid()` (defesa em
+-- profundidade) + search_path fixo + REVOKE PUBLIC + REVOKE anon + GRANT só
+-- para authenticated. Livros sem cronograma são omitidos do retorno
+-- (HAVING COUNT(*) > 0) -> invariante I-03 do data-model.
+--
+-- Adiciona o índice composto `schedule(owner, book_id)` que cobre o filtro
+-- principal da RPC, ausente antes desta migration.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.get_schedule_progress_for_books(
+  book_ids uuid[]
+)
+RETURNS TABLE (
+  book_id   uuid,
+  total     bigint,
+  completed bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+  SELECT
+    s.book_id,
+    COUNT(*)::bigint                                       AS total,
+    COUNT(*) FILTER (WHERE s.completed IS TRUE)::bigint    AS completed
+  FROM public.schedule s
+  WHERE s.owner   = auth.uid()
+    AND s.book_id = ANY(book_ids)
+  GROUP BY s.book_id
+  HAVING COUNT(*) > 0;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_schedule_progress_for_books(uuid[]) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_schedule_progress_for_books(uuid[]) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_schedule_progress_for_books(uuid[]) TO authenticated;
+
+CREATE INDEX IF NOT EXISTS schedule_owner_book_id_idx
+  ON public.schedule (owner, book_id);


### PR DESCRIPTION
Expõe progresso a partir do cronograma via RPC/API, consulta em lote na home (context), indicadores no BookCard e na página de cronograma, CTA quando não há agenda e clique para abrir o cronograma. Inclui migração Supabase, invalidação do cache agregado ao marcar leituras e especificação SDD 001.

## Summary by Sourcery

Add reading-schedule-based progress indicators to book cards and the schedule page, powered by a new aggregated schedule progress API and Supabase RPC.

New Features:
- Display reading progress derived from the user’s schedule on book cards in the home view for books in progress.
- Show a detailed reading progress section at the top of the schedule page based on the existing schedule data.
- Expose a new authenticated API endpoint and Supabase RPC to fetch aggregated reading progress for multiple books in a single request.
- Add an internal SDD spec and implementation plan for schedule-based reading progress.

Bug Fixes:
- Ensure optimistic schedule read toggles also invalidate aggregated reading progress cache entries to keep UI in sync.

Enhancements:
- Batch-load reading progress data on the home page via a shared context to avoid per-card requests and reuse cached results.
- Refine the generic progress UI component to support custom indicator styling and smoother transitions.
- Improve home and schedule hooks to integrate reading progress data while keeping book cards and tables presentation-focused.

Deployment:
- Introduce a new Supabase migration to define the schedule progress aggregation RPC and supporting index.

Documentation:
- Add SDD spec, data model, contracts, and checklists documenting the reading-progress-from-schedule feature.

Tests:
- Add tests for the new reading progress hooks, API route, Supabase RPC integration, and cache invalidation behavior.
- Extend existing home and schedule tests to cover query key stability and reading progress consistency.